### PR TITLE
feat: add-msvc-support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 cmake_policy(SET CMP0135 NEW)
 
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND "$ENV{CUDAARCHS}" STREQUAL "")
-  set(CMAKE_CUDA_ARCHITECTURES native CACHE STRING "Targeted CUDA architectures")
-endif()
+set(CMAKE_CUDA_ARCHITECTURES native CACHE STRING "Targeted CUDA architectures")
 
 if(MSVC)
   set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Available configuration types to select")
@@ -32,6 +30,8 @@ target_compile_options(cuda_battery INTERFACE
     # C.f. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=34678
     "$<$<AND:$<CXX_COMPILER_ID:GNU,Clang>,$<COMPILE_LANGUAGE:CUDA>,$<CUDA_COMPILER_ID:NVIDIA>>:SHELL:--compiler-options -frounding-math>"
     "$<$<CXX_COMPILER_ID:GNU,Clang>:-frounding-math>"
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/fp:strict>
+    "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CUDA_COMPILER_ID:NVIDIA>,$<CXX_COMPILER_ID:MSVC>>:SHELL:--compiler-options /fp:strict>"
 )
 
 if(REDUCE_PTX_SIZE)

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 # We compile the project for the native architecture, unless the user has specified a different architecture.
 # An architecture specification can be given at configuration time using `-DCMAKE_CUDA_ARCHITECTURES=75`.
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND "$ENV{CUDAARCHS}" STREQUAL "")
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   set(CMAKE_CUDA_ARCHITECTURES native CACHE STRING "Targeted CUDA architectures")
 endif()
 

--- a/demo/src/inkernel_allocation.cpp
+++ b/demo/src/inkernel_allocation.cpp
@@ -49,14 +49,14 @@ int main() {
   int supportsCoopLaunch = 0;
   cudaDeviceGetAttribute(&supportsCoopLaunch, cudaDevAttrCooperativeLaunch, dev);
   if (supportsCoopLaunch) {
-
       void *kernelArgs[] = { &ptr }; // be careful, we need to take the address of the parameter we wish to pass.
       dim3 dimBlock(256, 1, 1);
       dim3 dimGrid(256, 1, 1);
       cudaLaunchCooperativeKernel((void*)grid_vector_copy, dimGrid, dimBlock, kernelArgs);
       CUDAEX(cudaDeviceSynchronize());
+  } else {
+    std::cout << "Warning: The GPU device does not support launching a CUDA cooperative kernel." << std:endl;
   }
-
   mvector expected(100000, 42);
   if(expected != *ptr) {
     std::cout << "Error: the vector was modified by the kernel." << std::endl;

--- a/include/battery/vector.hpp
+++ b/include/battery/vector.hpp
@@ -311,8 +311,8 @@ public:
   }
 };
 
-template<class T, class Allocator>
-CUDA NI bool operator==(const vector<T, Allocator>& lhs, const vector<T, Allocator>& rhs) {
+template<class T1, class Alloc1, class T2, class Alloc2>
+CUDA NI bool operator==(const vector<T1, Alloc1>& lhs, const vector<T2, Alloc2>& rhs) {
   if(lhs.size() != rhs.size()) {
     return false;
   }
@@ -326,8 +326,8 @@ CUDA NI bool operator==(const vector<T, Allocator>& lhs, const vector<T, Allocat
   return true;
 }
 
-template<class T, class Allocator>
-CUDA bool operator!=(const vector<T, Allocator>& lhs, const vector<T, Allocator>& rhs) {
+template<class T1, class Alloc1, class T2, class Alloc2>
+CUDA bool operator!=(const vector<T1, Alloc1>& lhs, const vector<T2, Alloc2>& rhs) {
   return !(lhs == rhs);
 }
 

--- a/tests/unique_ptr_test_gpu.cpp
+++ b/tests/unique_ptr_test_gpu.cpp
@@ -67,7 +67,6 @@ void make_unique_grid_test() {
 }
 
 int main() {
-  battery::configuration::gpu.init();
   make_unique_block_test();
   int supportsCoopLaunch = 0;
   cudaDeviceGetAttribute(&supportsCoopLaunch, cudaDevAttrCooperativeLaunch, 0);
@@ -77,5 +76,6 @@ int main() {
   else {
     printf("Note: skipping unique_ptr grid test because device does not support cooperative launch.\n");
   }
+  printf("unique_ptr_test_gpu complete.\n");
   return 0;
 }

--- a/tests/utility_test_cpu_gpu.cpp
+++ b/tests/utility_test_cpu_gpu.cpp
@@ -240,10 +240,11 @@ void test_bitwise_operations() {
 }
 
 int main() {
-  battery::configuration::gpu.init();
   test_all_casts();
   test_bitwise_operations<unsigned char>();
   test_bitwise_operations<unsigned short>();
   test_bitwise_operations<unsigned int>();
   test_bitwise_operations<unsigned long long int>();
+  printf("utility_test_cpu_gpu complete.\n");
+  return 0;
 }


### PR DESCRIPTION
## Add support for Microsoft Visual C/C++

* Update CMakeLists.txt for MSVC.

* Fix the printf specifiers to use the macro `PRIu64` in device code for size_t. (Should be "%zu", but CUDA printf does not support it.)

* Fix MSVC compiler issue: `constexpr nextafter` (officially not available until C++23).

* Add `/fp:strict` for MSVC in lieu of `#pragma fenv_access(on)`.

* Add [/NODEFAULTLIB](https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4098?view=msvc-170) to avoid a CUDA linker [conflict issue](https://stackoverflow.com/questions/72780153/linker-warning-when-building-cuda-c-code-in-debug-mode-using-vs2022) when building a Debug release.

* Add `GIT_SHALLOW 1` to reduce the fetch times for big dependent packages like [cccl](https://github.com/NVIDIA/cccl).

* Change `CMAKE_CUDA_ARCHTECTURES` to be configurable.

* Set the default `CMAKE_CONFIGURATION_TYPES` to `Debug;Release` for MSVC. This is required because MSVC is a [multi-config](https://cmake.org/cmake/help/latest/prop_gbl/GENERATOR_IS_MULTI_CONFIG.html) CMake generator. Otherwise the property defaults to empty, and nothing gets built.

* Add a new memory allocator `pinned_allocator` to allocate
pinned memory to permit communication between the CPU and GPU
while the GPU kernel is running on a GPU that does not support
concurrent access to managed memory (see **Windows Limitation** below).

* Add a new memory allocator `concurrent_allocator` to allocate
memory to permit communication between the CPU and GPU
while the GPU kernel is running.  It uses `managed_allocator`
when supported, falling back to `pinned_allocator` if
necessary on GPUs that do not support concurrent access
to managed memory (see below).

### Windows Limitation: No Concurrent Access to Managed Memory

The NVIDIA drivers for Microsoft Windows, the Windows Subsystem for Linux [WSL],
NVIDIA GRID (vGPU), and macOS do not support access to managed memory by
the host when a CUDA device kernel is running.
(`cudaDevAttrConcurrentManagedAccess` is always false.)
The result is a segfault.

To work around the limitation, use the memory allocator
`concurrent_allocator` to allocate memory for fields that
require concurrent access between the CPU and GPU while a GPU kernel
is running.

### NVIDIA GRID Limitation: No Unified Memory on vGPUs

Turbo will not run when Unified Memory is not available.
There is no workaround.

>
> ### [2.10 Unified Memory Support](https://docs.nvidia.com/ai-enterprise/2.3/release-notes/index.html)
>
> Unified memory is a single memory address space that is accessible from
> any CPU or GPU in a system. It creates a pool of managed memory that is
> shared between the CPU and GPU to provide a simple way to allocate and
> access data that can be used by code running on any CPU or GPU in the system.
> Unified memory is supported only on a subset of vGPUs and guest OS releases...
>
> Only time-sliced vGPUs that are allocated all of the physical GPU's
> frame buffer on physical GPUs that support unified memory are supported.
>
> Linux only. Unified memory is **not** supported on Windows.
>
> When unified memory is enabled for a VM, vGPU migration is disabled
> for the VM.
>

When using a vGPU, calls from Turbo to `cudaMallocManaged()` can fail with `cudaErrorNotSupported`.

### List of Pull Requests

There are a total of seven PRs, one for each repository: cuda-battery, lala-core, lala-parsing, lala-pc, lala-power, and cpp-peglib, and turbo. The PRs need to be applied simultaneously with incremented version tags (v1.1.x).
