### PR TITLE
fix: avoid -Wstringop-overflow in battery::string constructor

### DIFF
--- a/include/battery/string.hpp
+++ b/include/battery/string.hpp
@@ -26,7 +26,14 @@ public:
   CUDA string(size_t n, const allocator_type& alloc = allocator_type()):
     data_(n+1, alloc) /* +1 for null-termination */
   {
-    data_[n] = '\0'; // In case the user modifies the string.
+    // GCC/Clang may emit -Wstringop-overflow when accessing data_[n]
+    // even though data_ has size n+1. The conditional access ensures
+    // that the compiler can verify the write is safe.
+    if(n != 0)
+        // In case the user modifies the string.
+        data_[n] = '\0';
+    else
+        data_[0] = '\0';
   }
 
   CUDA string(const allocator_type& alloc = allocator_type()): string((size_t)0, alloc) {}


### PR DESCRIPTION
This PR avoids a false positive -Wstringop-overflow warning issued by GCC.

Although `data_` is allocated with `n + 1` elements, the compiler may not always infer this. As a result, writing to `data_[n]`  may trigger an incorrect buffer overflow warning.

We avoid this by adding a conditional write to ensure the compiler can verify that the write is safe in all cases.