### PR TITLE
WIP: Add HIP backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,21 @@ if(MSVC)
   set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Available configuration types to select")
 endif()
 
-option(GPU "GPU" ON)
-if(GPU)
+option(GPU "Build with CUDA GPU support" ON)
+option(HIP "Build with HIP GPU support (AMD ROCm or NVIDIA via HIP)" OFF)
+
+if(GPU AND HIP)
+  message(FATAL_ERROR "GPU (CUDA) and HIP options are mutually exclusive. Choose one backend.")
+endif()
+
+if(HIP)
+  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES)
+    set(CMAKE_HIP_ARCHITECTURES native CACHE STRING "Targeted HIP architectures")
+  endif()
+  project(cuda-battery
+    HOMEPAGE_URL "https://github.com/lattice-land/cuda-battery"
+    LANGUAGES HIP CXX)
+elseif(GPU)
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES native CACHE STRING "Targeted CUDA architectures")
   endif()
@@ -41,6 +54,9 @@ target_compile_options(cuda_battery INTERFACE
     "$<$<CXX_COMPILER_ID:GNU,Clang>:-frounding-math>"
     $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/fp:strict>
     "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CUDA_COMPILER_ID:NVIDIA>,$<CXX_COMPILER_ID:MSVC>>:SHELL:--compiler-options /fp:strict>"
+    # HIP compile options (hipcc on AMD ROCm or NVIDIA via HIP_PLATFORM=nvidia)
+    "$<$<COMPILE_LANGUAGE:HIP>:--expt-relaxed-constexpr>"
+    "$<$<AND:$<COMPILE_LANGUAGE:HIP>,$<CONFIG:Debug>>:-ggdb>"
 )
 
 if(REDUCE_PTX_SIZE)
@@ -85,6 +101,18 @@ if(GPU)
     target_link_libraries(${test_name} cuda_battery)
     target_link_options(${test_name} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/NODEFAULTLIB:LIBCMT>)
     add_test(NAME ${test_name} COMMAND compute-sanitizer --error-exitcode 1 $<TARGET_FILE:${test_name}>)
+  endforeach()
+endif()
+
+# III. HIP GPU Tests (ending with "_hip.cpp")
+if(HIP)
+  file(GLOB hip_test_files tests/*_hip.cpp)
+  foreach(file ${hip_test_files})
+    cmake_path(GET file STEM test_name)
+    set_source_files_properties(${file} PROPERTIES LANGUAGE HIP)
+    add_executable(${test_name} ${file})
+    target_link_libraries(${test_name} cuda_battery)
+    add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
   endforeach()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ if(HIP)
   project(cuda-battery
     HOMEPAGE_URL "https://github.com/lattice-land/cuda-battery"
     LANGUAGES HIP CXX)
+  # find_package(hip) provides hip::host which handles HIP runtime linking on both
+  # AMD (amdhip64) and NVIDIA (wraps cudart).  CUDA::cuda_driver is needed on NVIDIA
+  # because hipDeviceGetAttribute routes through the CUDA driver API (libcuda.so).
+  find_package(hip REQUIRED)
+  find_package(CUDAToolkit QUIET)
 elseif(GPU)
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES native CACHE STRING "Targeted CUDA architectures")
@@ -61,6 +66,19 @@ target_compile_options(cuda_battery INTERFACE
 
 if(REDUCE_PTX_SIZE)
   target_compile_definitions(cuda_battery INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:REDUCE_PTX_SIZE>")
+endif()
+
+# When building with HIP=ON, link hip::host so both AMD and NVIDIA HIP builds get
+# the correct HIP runtime libraries through a single CMake target.
+if(HIP)
+  target_link_libraries(cuda_battery INTERFACE hip::host)
+endif()
+
+# When building with HIP=ON (either AMD or NVIDIA via HIP), expose BATTERY_HIP_BUILD
+# so that utility.hpp makes HIPE/HIPEX available even when nvcc is the compiler
+# (hip-nvidia-* presets: __CUDACC__ is defined but HIP headers are in scope).
+if(HIP)
+  target_compile_definitions(cuda_battery INTERFACE BATTERY_HIP_BUILD)
 endif()
 
 if(CUDA_BATTERY_BUILD_TESTS)
@@ -106,12 +124,20 @@ endif()
 
 # III. HIP GPU Tests (ending with "_hip.cpp")
 if(HIP)
+  # HIP runtime on NVIDIA routes device-attribute queries through the CUDA Driver
+  # API (cuDeviceGetAttribute in libcuda.so). CMake's implicit HIP link only adds
+  # libcudart_static; link CUDA::cuda_driver explicitly so hipDeviceGetAttribute works.
+  find_package(CUDAToolkit REQUIRED)
+
   file(GLOB hip_test_files tests/*_hip.cpp)
   foreach(file ${hip_test_files})
     cmake_path(GET file STEM test_name)
     set_source_files_properties(${file} PROPERTIES LANGUAGE HIP)
     add_executable(${test_name} ${file})
     target_link_libraries(${test_name} cuda_battery)
+    if(CUDAToolkit_FOUND)
+      target_link_libraries(${test_name} CUDA::cuda_driver)
+    endif()
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
   endforeach()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -107,6 +107,50 @@
       "displayName": "CPU Release configuration",
       "description": "Build the project with a CPU compiler such as GCC.",
       "inherits": ["default-cpu","release"]
+    },
+    {
+      "name": "default-hip",
+      "hidden": true,
+      "inherits": "default",
+      "cacheVariables": {
+        "GPU": { "type": "BOOL", "value": "OFF" },
+        "HIP": { "type": "BOOL", "value": "ON" }
+      }
+    },
+    {
+      "name": "default-hip-nvidia",
+      "hidden": true,
+      "inherits": "default-hip",
+      "environment": {
+        "HIP_PLATFORM": "nvidia"
+      },
+      "cacheVariables": {
+        "CMAKE_HIP_ARCHITECTURES": "native"
+      }
+    },
+    {
+      "name": "hip-debug",
+      "displayName": "HIP Debug (AMD ROCm)",
+      "description": "Build using hipcc targeting AMD GPUs.",
+      "inherits": ["default-hip", "debug", "verbose"]
+    },
+    {
+      "name": "hip-release",
+      "displayName": "HIP Release (AMD ROCm)",
+      "description": "Build using hipcc targeting AMD GPUs.",
+      "inherits": ["default-hip", "release"]
+    },
+    {
+      "name": "hip-nvidia-debug",
+      "displayName": "HIP Debug - NVIDIA backend [temporary]",
+      "description": "Build using hipcc with HIP_PLATFORM=nvidia. Used to develop and validate HIP support on NVIDIA hardware before testing on AMD. Remove once AMD testing is established.",
+      "inherits": ["default-hip-nvidia", "debug", "verbose"]
+    },
+    {
+      "name": "hip-nvidia-release",
+      "displayName": "HIP Release - NVIDIA backend [temporary]",
+      "description": "See hip-nvidia-debug. Remove once AMD testing is established.",
+      "inherits": ["default-hip-nvidia", "release"]
     }
   ],
   "buildPresets": [
@@ -125,6 +169,22 @@
     {
       "name": "cpu-release",
       "configurePreset": "cpu-release"
+    },
+    {
+      "name": "hip-debug",
+      "configurePreset": "hip-debug"
+    },
+    {
+      "name": "hip-release",
+      "configurePreset": "hip-release"
+    },
+    {
+      "name": "hip-nvidia-debug",
+      "configurePreset": "hip-nvidia-debug"
+    },
+    {
+      "name": "hip-nvidia-release",
+      "configurePreset": "hip-nvidia-release"
     }
   ],
   "testPresets": [
@@ -143,6 +203,22 @@
     {
       "name": "cpu-release",
       "configurePreset": "cpu-release"
+    },
+    {
+      "name": "hip-debug",
+      "configurePreset": "hip-debug"
+    },
+    {
+      "name": "hip-release",
+      "configurePreset": "hip-release"
+    },
+    {
+      "name": "hip-nvidia-debug",
+      "configurePreset": "hip-nvidia-debug"
+    },
+    {
+      "name": "hip-nvidia-release",
+      "configurePreset": "hip-nvidia-release"
     }
   ],
   "workflowPresets": [
@@ -200,18 +276,41 @@
     {
       "name": "gpu-release",
       "steps": [
-        {
-          "type": "configure",
-          "name": "gpu-release"
-        },
-        {
-          "type": "build",
-          "name": "gpu-release"
-        },
-        {
-          "type": "test",
-          "name": "gpu-release"
-        }
+        { "type": "configure", "name": "gpu-release" },
+        { "type": "build",     "name": "gpu-release" },
+        { "type": "test",      "name": "gpu-release" }
+      ]
+    },
+    {
+      "name": "hip-debug",
+      "steps": [
+        { "type": "configure", "name": "hip-debug" },
+        { "type": "build",     "name": "hip-debug" },
+        { "type": "test",      "name": "hip-debug" }
+      ]
+    },
+    {
+      "name": "hip-release",
+      "steps": [
+        { "type": "configure", "name": "hip-release" },
+        { "type": "build",     "name": "hip-release" },
+        { "type": "test",      "name": "hip-release" }
+      ]
+    },
+    {
+      "name": "hip-nvidia-debug",
+      "steps": [
+        { "type": "configure", "name": "hip-nvidia-debug" },
+        { "type": "build",     "name": "hip-nvidia-debug" },
+        { "type": "test",      "name": "hip-nvidia-debug" }
+      ]
+    },
+    {
+      "name": "hip-nvidia-release",
+      "steps": [
+        { "type": "configure", "name": "hip-nvidia-release" },
+        { "type": "build",     "name": "hip-nvidia-release" },
+        { "type": "test",      "name": "hip-nvidia-release" }
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
-# Standard Library for CUDA Programming
+# Standard Library for CUDA/HIP Programming
 
 [![Build Status](https://travis-ci.com/lattice-land/cuda-battery.svg?branch=main)](https://travis-ci.com/lattice-land/cuda-battery)
 
-This library provides data structures to ease programming in CUDA (version 12 or higher).
+This library provides data structures to ease GPU programming in CUDA (version 12 or higher) and HIP (ROCm 6+).
 For a tutorial and further information, please read [this manual](https://lattice-land.github.io/1-cuda-battery.html).
 
+## Supported Backends
+
+| Backend | Compiler | CMake option | Active macro |
+|---|---|---|---|
+| CPU only | GCC / Clang / MSVC | _(default)_ | — |
+| CUDA (NVIDIA) | nvcc 12+ | `GPU=ON` | `BATTERY_CUDA_BACKEND` |
+| HIP (AMD ROCm) | amdclang++ / hipcc, ROCm 6+ | `HIP=ON GPU=OFF` | `BATTERY_HIP_BACKEND` |
+
+The three backends are mutually exclusive at compile time.
+
 ## Example
+
+The example below works unchanged on both CUDA and HIP — just compile with the appropriate backend option.
+For HIP, replace `CUDAEX` with `HIPEX` and `cudaDeviceSynchronize` with `hipDeviceSynchronize`.
 
 Quick example on how to transfer a `std::vector` on CPU to a `battery::vector` on GPU (notice you don't need to do any manual memory allocation or deallocation):
 
@@ -60,6 +73,7 @@ int main(int argc, char** argv) {
 | Containers | [`vector`](https://lattice-land.github.io/cuda-battery/vector_8hpp.html) ([`std`](https://en.cppreference.com/w/cpp/container/vector)) | [`string`](https://lattice-land.github.io/cuda-battery/string_8hpp.html) ([`std`](https://en.cppreference.com/w/cpp/string/basic_string)) | [`dynamic_bitset`](https://lattice-land.github.io/cuda-battery/dynamic__bitset_8hpp.html) | |
 | | [`tuple`](https://en.cppreference.com/w/cpp/utility/tuple) | [`variant`](https://lattice-land.github.io/cuda-battery/variant_8hpp.html) ([`std`](https://en.cppreference.com/w/cpp/utility/variant)) | [`bitset`](https://lattice-land.github.io/cuda-battery/bitset_8hpp.html) ([`std`](https://en.cppreference.com/w/cpp/utility/bitset)) | |
 | Utility | [`CUDA`](https://lattice-land.github.io/cuda-battery/utility_8hpp.html#a7b01e29f669d6beed251f1b2a547ca93) | [`INLINE`](https://lattice-land.github.io/cuda-battery/utility_8hpp.html#a2eb6f9e0395b47b8d5e3eeae4fe0c116) | [`CUDAE`](https://lattice-land.github.io/cuda-battery/utility_8hpp.html#a289596c1db721f82251de6902f9699db) | [`CUDAEX`](https://lattice-land.github.io/cuda-battery/utility_8hpp.html#af35c92d967acfadd086658422f631100) |
+| | | | [`HIPE`](https://lattice-land.github.io/cuda-battery/utility_8hpp.html) _(HIP)_ | [`HIPEX`](https://lattice-land.github.io/cuda-battery/utility_8hpp.html) _(HIP)_ |
 | | [`limits`](https://lattice-land.github.io/cuda-battery/structbattery_1_1limits.html) | [`ru_cast`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#a7fdea425c76eab201a009ea09b8cbac0) | [`rd_cast`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#aa2296c962277e71780bccf1ba9708f59) | |
 | | [`popcount`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#a2821ae67e8ea81b375f3fd6d70909fef) ([`std`](https://en.cppreference.com/w/cpp/numeric/popcount)) | [`countl_zero`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#aa18a34122dc3e8b7e96c4a54eeffa9aa) ([`std`](https://en.cppreference.com/w/cpp/numeric/countl_zero)) | [`countl_one`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#ae252a50e577d7b092eb368b7e0289772) ([`std`](https://en.cppreference.com/w/cpp/numeric/countl_one)) | [`countr_zero`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#a7338f90fab224e49c3716c5eace58bee) ([`std`](https://en.cppreference.com/w/cpp/numeric/countr_zero)) |
 | | [`countr_one`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#a974d0a682d546e1185ae7dca29c272d6) ([`std`](https://en.cppreference.com/w/cpp/numeric/countr_one)) | [`signum`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#a31b3f5ee3799a73d29c153ebd222cdea) | [`ipow`](https://lattice-land.github.io/cuda-battery/namespacebattery.html#a93472d80842253624e2436eef7b900b6) | |

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -27,6 +27,8 @@ if(HIP)
   project(cuda-battery-demo
     HOMEPAGE_URL "https://github.com/lattice-land/cuda-battery"
     LANGUAGES HIP CXX)
+  find_package(hip REQUIRED)
+  find_package(CUDAToolkit QUIET)
 else()
   project(cuda-battery-demo
     HOMEPAGE_URL "https://github.com/lattice-land/cuda-battery"
@@ -63,9 +65,15 @@ if(HIP)
   add_executable(demo_hip src/demo_hip.cpp)
   target_include_directories(demo_hip PRIVATE include)
   target_link_libraries(demo_hip cuda_battery)
+  if(CUDAToolkit_FOUND)
+    target_link_libraries(demo_hip CUDA::cuda_driver)
+  endif()
 
   add_executable(inkernel_allocation_hip src/inkernel_allocation_hip.cpp)
   target_link_libraries(inkernel_allocation_hip cuda_battery)
+  if(CUDAToolkit_FOUND)
+    target_link_libraries(inkernel_allocation_hip CUDA::cuda_driver)
+  endif()
 
   add_executable(simple_hip src/simple_hip.cpp)
   target_link_libraries(simple_hip cuda_battery)
@@ -140,6 +148,9 @@ if(HIP)
     add_executable(${test_name} ${file})
     target_include_directories(${test_name} PRIVATE include)
     target_link_libraries(${test_name} cuda_battery)
+    if(CUDAToolkit_FOUND)
+      target_link_libraries(${test_name} CUDA::cuda_driver)
+    endif()
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
   endforeach()
 

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -8,16 +8,30 @@ endif()
 
 # I. Project main description and options.
 
+option(HIP "Build with HIP GPU support (AMD ROCm or NVIDIA via HIP)" OFF)
+
 # We compile the project for the native architecture, unless the user has specified a different architecture.
-# An architecture specification can be given at configuration time using `-DCMAKE_CUDA_ARCHITECTURES=75`.
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES native CACHE STRING "Targeted CUDA architectures")
+if(HIP)
+  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES)
+    set(CMAKE_HIP_ARCHITECTURES native CACHE STRING "Targeted HIP architectures")
+  endif()
+else()
+  # An architecture specification can be given at configuration time using `-DCMAKE_CUDA_ARCHITECTURES=75`.
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES native CACHE STRING "Targeted CUDA architectures")
+  endif()
 endif()
 
 # Name and information about this project.
-project(cuda-battery-demo
-  HOMEPAGE_URL "https://github.com/lattice-land/cuda-battery"
-  LANGUAGES CUDA CXX)
+if(HIP)
+  project(cuda-battery-demo
+    HOMEPAGE_URL "https://github.com/lattice-land/cuda-battery"
+    LANGUAGES HIP CXX)
+else()
+  project(cuda-battery-demo
+    HOMEPAGE_URL "https://github.com/lattice-land/cuda-battery"
+    LANGUAGES CUDA CXX)
+endif()
 
 # An option to build the project with the tests activated or not (tests are built by default here).
 option(CUDA_BATTERY_DEMO_BUILD_TESTS "CUDA_BATTERY_DEMO_BUILD_TESTS" ON)
@@ -35,43 +49,66 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(cuda_battery)
 
-# III. Build the main executable.
+# III. Build the main executables.
 
-# Add any `.cpp` files that contains CUDA code here.
-# If you want to keep `.cu` files, simply delete this command.
-set_source_files_properties(
-  src/demo.cpp
-  src/inkernel_allocation.cpp
-  src/simple.cpp
-  PROPERTIES LANGUAGE CUDA)
+if(HIP)
 
-# Multiple CUDA files?
-# If you have several `.cpp` files with CUDA code, you must activate separable compilation:
-# set_property(TARGET demo APPEND PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+  # HIP variants of the three demo executables.
+  set_source_files_properties(
+    src/demo_hip.cpp
+    src/inkernel_allocation_hip.cpp
+    src/simple_hip.cpp
+    PROPERTIES LANGUAGE HIP)
 
-# This is the main executable, add any additional `.cpp` files required to compile the project here, for instance:
-# add_executable(demo src/demo.cpp src/config.cpp)
-add_executable(demo src/demo.cpp)
+  add_executable(demo_hip src/demo_hip.cpp)
+  target_include_directories(demo_hip PRIVATE include)
+  target_link_libraries(demo_hip cuda_battery)
 
-# Add the include directory.
-target_include_directories(demo PRIVATE include)
+  add_executable(inkernel_allocation_hip src/inkernel_allocation_hip.cpp)
+  target_link_libraries(inkernel_allocation_hip cuda_battery)
 
-# We include the library `cuda_battery` (it is not really linked since it is just a header-only library, that's just the CMake terminology), note that all the compile options of cuda_battery are inherited by the executable.
-target_link_libraries(demo cuda_battery)
+  add_executable(simple_hip src/simple_hip.cpp)
+  target_link_libraries(simple_hip cuda_battery)
 
-# The executable inherits the compiler options of cuda_battery.
-# We also delete warnings telling us that calling __host__ from __host__ __device__ is forbidden (they are generated due to templated functions working on both CPU/GPU).
-target_compile_options(demo PRIVATE
-  "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-diag-suppress 20011,20014>"
-)
+else()
 
-# Describe the second executable.
-add_executable(inkernel_allocation src/inkernel_allocation.cpp)
-target_link_libraries(inkernel_allocation cuda_battery)
+  # Add any `.cpp` files that contain CUDA code here.
+  # If you want to keep `.cu` files, simply delete this command.
+  set_source_files_properties(
+    src/demo.cpp
+    src/inkernel_allocation.cpp
+    src/simple.cpp
+    PROPERTIES LANGUAGE CUDA)
 
-# Describe the third executable.
-add_executable(simple src/simple.cpp)
-target_link_libraries(simple cuda_battery)
+  # Multiple CUDA files?
+  # If you have several `.cpp` files with CUDA code, you must activate separable compilation:
+  # set_property(TARGET demo APPEND PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+
+  # This is the main executable, add any additional `.cpp` files required to compile the project here, for instance:
+  # add_executable(demo src/demo.cpp src/config.cpp)
+  add_executable(demo src/demo.cpp)
+
+  # Add the include directory.
+  target_include_directories(demo PRIVATE include)
+
+  # We include the library `cuda_battery` (it is not really linked since it is just a header-only library, that's just the CMake terminology), note that all the compile options of cuda_battery are inherited by the executable.
+  target_link_libraries(demo cuda_battery)
+
+  # The executable inherits the compiler options of cuda_battery.
+  # We also delete warnings telling us that calling __host__ from __host__ __device__ is forbidden (they are generated due to templated functions working on both CPU/GPU).
+  target_compile_options(demo PRIVATE
+    "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-diag-suppress 20011,20014>"
+  )
+
+  # Describe the second executable.
+  add_executable(inkernel_allocation src/inkernel_allocation.cpp)
+  target_link_libraries(inkernel_allocation cuda_battery)
+
+  # Describe the third executable.
+  add_executable(simple src/simple.cpp)
+  target_link_libraries(simple cuda_battery)
+
+endif()
 
 # IV. Build and execute the CPU and GPU tests.
 # You can simply add new CPU tests by adding a new file in `tests/`, and GPU tests by terminating the filename with "gpu".
@@ -93,24 +130,43 @@ FetchContent_MakeAvailable(googletest)
 enable_testing()
 include(GoogleTest)
 
-file(GLOB test_files tests/*.cpp)
-foreach(file ${test_files})
-  cmake_path(GET file STEM test_name)
-  set_source_files_properties(${file} PROPERTIES LANGUAGE CUDA)
-  add_executable(${test_name} ${file})
-  target_include_directories(${test_name} PRIVATE include)
-  target_compile_options(${test_name} PRIVATE
-    "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-diag-suppress 20011,20014>"
-  )
-  if(${test_name} MATCHES ".*gpu$")
+if(HIP)
+
+  # HIP GPU tests (files ending with _hip.cpp).
+  file(GLOB hip_test_files tests/*_hip.cpp)
+  foreach(file ${hip_test_files})
+    cmake_path(GET file STEM test_name)
+    set_source_files_properties(${file} PROPERTIES LANGUAGE HIP)
+    add_executable(${test_name} ${file})
+    target_include_directories(${test_name} PRIVATE include)
     target_link_libraries(${test_name} cuda_battery)
-    # We run the tests using compute-sanitizer to check for memory leaks.
-    add_test(NAME ${test_name} COMMAND compute-sanitizer --error-exitcode 1 $<TARGET_FILE:${test_name}>)
-  else()
-    target_link_libraries(${test_name} cuda_battery gtest_main)
-    gtest_discover_tests(${test_name})
-  endif()
-endforeach()
+    add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
+  endforeach()
+
+else()
+
+  # CUDA tests: exclude any _hip.cpp files that may be present in the folder.
+  file(GLOB test_files tests/*.cpp)
+  list(FILTER test_files EXCLUDE REGEX ".*_hip\.cpp$")
+  foreach(file ${test_files})
+    cmake_path(GET file STEM test_name)
+    set_source_files_properties(${file} PROPERTIES LANGUAGE CUDA)
+    add_executable(${test_name} ${file})
+    target_include_directories(${test_name} PRIVATE include)
+    target_compile_options(${test_name} PRIVATE
+      "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-diag-suppress 20011,20014>"
+    )
+    if(${test_name} MATCHES ".*gpu$")
+      target_link_libraries(${test_name} cuda_battery)
+      # We run the tests using compute-sanitizer to check for memory leaks.
+      add_test(NAME ${test_name} COMMAND compute-sanitizer --error-exitcode 1 $<TARGET_FILE:${test_name}>)
+    else()
+      target_link_libraries(${test_name} cuda_battery gtest_main)
+      gtest_discover_tests(${test_name})
+    endif()
+  endforeach()
+
+endif()
 
 endif()
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,18 +1,76 @@
-# Battery for CUDA programming
+# Battery for CUDA/HIP programming
 
 Companion code for the [CUDA battery tutorial](https://lattice-land.github.io/CUDA-Battery.html).
-It can be copied to start your own CUDA/CMake project.
+It can be copied to start your own CUDA/HIP/CMake project.
+
+## CUDA (NVIDIA)
 
 To compile in release mode:
 ```
-mkdir -p build/gpu-release
-cmake -DCMAKE_BUILD_TYPE=Release -DDEMO_BUILD_TESTS=ON -Bbuild/gpu-release &&
+cmake -DCMAKE_BUILD_TYPE=Release -DCUDA_BATTERY_DEMO_BUILD_TESTS=ON -Bbuild/gpu-release &&
 cmake --build build/gpu-release
 ```
 
 And in debug mode:
 ```
-mkdir -p build/gpu-debug
-cmake -DCMAKE_BUILD_TYPE=Debug -DDEMO_BUILD_TESTS=ON -Bbuild/gpu-debug &&
+cmake -DCMAKE_BUILD_TYPE=Debug -DCUDA_BATTERY_DEMO_BUILD_TESTS=ON -Bbuild/gpu-debug &&
 cmake --build build/gpu-debug
 ```
+
+To run the tests:
+```
+cd build/gpu-debug && ctest --output-on-failure
+```
+
+To run the executables:
+```
+./build/gpu-debug/demo gpu 10000 256
+./build/gpu-debug/simple
+./build/gpu-debug/inkernel_allocation
+```
+
+## HIP (AMD ROCm)
+
+Requires ROCm installed (tested with ROCm 6.2+).
+
+To compile in release mode:
+```
+cmake -DHIP=ON -DGPU=OFF -DCMAKE_BUILD_TYPE=Release -DCUDA_BATTERY_DEMO_BUILD_TESTS=ON -Bbuild/hip-release &&
+cmake --build build/hip-release
+```
+
+And in debug mode:
+```
+cmake -DHIP=ON -DGPU=OFF -DCMAKE_BUILD_TYPE=Debug -DCUDA_BATTERY_DEMO_BUILD_TESTS=ON -Bbuild/hip-debug &&
+cmake --build build/hip-debug
+```
+
+To run the tests:
+```
+cd build/hip-debug && ctest --output-on-failure
+```
+
+To run the executables:
+```
+./build/hip-debug/demo_hip gpu 10000 256
+./build/hip-debug/simple_hip
+./build/hip-debug/inkernel_allocation_hip
+```
+
+### HIP on NVIDIA (temporary, for development only)
+
+If you are developing on an NVIDIA machine and want to verify the HIP build
+infrastructure without AMD hardware, set `HIP_PLATFORM=nvidia`:
+
+```
+HIP_PLATFORM=nvidia cmake -DHIP=ON -DGPU=OFF -DCMAKE_BUILD_TYPE=Debug \
+  -DCUDA_BATTERY_DEMO_BUILD_TESTS=ON -Bbuild/hip-nvidia-debug &&
+cmake --build build/hip-nvidia-debug
+```
+
+> **Note:** With `HIP_PLATFORM=nvidia`, CMake selects nvcc as the HIP compiler,
+> so `BATTERY_CUDA_BACKEND` is active rather than `BATTERY_HIP_BACKEND`.
+> This verifies that the HIP-language build system works but does **not** exercise
+> the HIP API code paths. Those are only exercised on AMD hardware with the
+> standard HIP build above. The `hip-nvidia` build variant will be removed once
+> AMD testing is established.

--- a/demo/src/demo_hip.cpp
+++ b/demo/src/demo_hip.cpp
@@ -10,25 +10,14 @@
 
 #include "par_map.hpp"
 
-// TODO: Remove this alias block once AMD verification is complete.
-// On AMD hardware BATTERY_HIP_BACKEND is always active; inline the HIP calls directly.
-#ifdef BATTERY_CUDA_BACKEND
-  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
+// Uses the HIP API unconditionally.  On NVIDIA (hip-nvidia-*) BATTERY_HIP_BUILD is set
+// by CMake so hip/hip_runtime.h is in scope; hip* calls map to cuda* via HIP headers.
 
-  static size_t max_shared_mem() {
-    cudaDeviceProp deviceProp;
-    cudaGetDeviceProperties(&deviceProp, 0);
-    return deviceProp.sharedMemPerBlock;
-  }
-#elif defined(BATTERY_HIP_BACKEND)
-  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
-
-  static size_t max_shared_mem() {
-    hipDeviceProp_t deviceProp;
-    HIPEX(hipGetDeviceProperties(&deviceProp, 0));
-    return deviceProp.sharedMemPerBlock;
-  }
-#endif
+static size_t max_shared_mem() {
+  hipDeviceProp_t deviceProp;
+  HIPEX(hipGetDeviceProperties(&deviceProp, 0));
+  return deviceProp.sharedMemPerBlock;
+}
 
 /** Different aliases to `vector` with different allocators. */
 using mvector = battery::vector<int, battery::managed_allocator>;
@@ -77,7 +66,7 @@ void map_gpu(std::vector<int>& v, size_t num_blocks) {
     printf("GPU execution with global memory with %zu blocks.\n", num_blocks);
     map_kernel<<<num_blocks, 256>>>(gpu_v.get());
   }
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   // Transferring the new data to the initial vector.
   for(int i = 0; i < (int)v.size(); ++i) {
     v[i] = (*gpu_v)[i];

--- a/demo/src/demo_hip.cpp
+++ b/demo/src/demo_hip.cpp
@@ -1,0 +1,110 @@
+// Copyright 2026 Ludovic Temgoua Abanda
+// HIP version of demo.cpp.
+// Compiled as HIP language by CMake when HIP=ON.
+
+#include <vector>
+#include <string>
+#include "battery/vector.hpp"
+#include "battery/unique_ptr.hpp"
+#include "battery/allocator.hpp"
+
+#include "par_map.hpp"
+
+// TODO: Remove this alias block once AMD verification is complete.
+// On AMD hardware BATTERY_HIP_BACKEND is always active; inline the HIP calls directly.
+#ifdef BATTERY_CUDA_BACKEND
+  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
+
+  static size_t max_shared_mem() {
+    cudaDeviceProp deviceProp;
+    cudaGetDeviceProperties(&deviceProp, 0);
+    return deviceProp.sharedMemPerBlock;
+  }
+#elif defined(BATTERY_HIP_BACKEND)
+  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
+
+  static size_t max_shared_mem() {
+    hipDeviceProp_t deviceProp;
+    HIPEX(hipGetDeviceProperties(&deviceProp, 0));
+    return deviceProp.sharedMemPerBlock;
+  }
+#endif
+
+/** Different aliases to `vector` with different allocators. */
+using mvector = battery::vector<int, battery::managed_allocator>;
+using gvector = battery::vector<int, battery::global_allocator>;
+using pvector = battery::vector<int, battery::pool_allocator>;
+
+/** Example of a kernel applying a map function to a vector in managed memory. */
+__global__ void map_kernel(mvector* v_ptr) {
+  grid_par_map(*v_ptr, [](int x){ return x * 2; });
+}
+
+/** Similar to `map_kernel`, but first moves chunks of the vector to shared memory. */
+__global__ void map_kernel_shared(mvector* v_ptr, size_t shared_mem_capacity) {
+  // I. Create a pool of shared memory.
+  extern __shared__ unsigned char shared_mem[];
+  battery::unique_ptr<battery::pool_allocator, battery::global_allocator> pool_ptr;
+  // /!\ We must take a reference to the pool_allocator to avoid copying it, because its copy-constructor is not thread-safe!
+  battery::pool_allocator& shared_mem_pool = battery::make_unique_block(pool_ptr, static_cast<unsigned char*>(shared_mem), shared_mem_capacity);
+
+  // II. Transfer from global memory to shared memory.
+  battery::unique_ptr<pvector, battery::global_allocator> shared_vector;
+  size_t chunk_size = chunk_size_per_block(*v_ptr, gridDim.x);
+  auto span = make_safe_span(*v_ptr, chunk_size * blockIdx.x, chunk_size);
+  pvector& v = battery::make_unique_block(shared_vector, span.data(), span.size(), shared_mem_pool);
+
+  // III. Run the algorithm on the shared memory.
+  block_par_map(v, [](int x){ return x * 2; }, blockDim.x, threadIdx.x);
+  __syncthreads();
+
+  // IV. Transfer back from shared memory to global memory.
+  for(int i = threadIdx.x; i < (int)v.size(); i += blockDim.x) {
+    (*v_ptr)[chunk_size * blockIdx.x + i] = v[i];
+  }
+}
+
+/** Function running a GPU kernel, either with shared memory if the vector `v` is small enough, or in global memory otherwise. */
+void map_gpu(std::vector<int>& v, size_t num_blocks) {
+  size_t chunk_size_bytes = sizeof(int) * chunk_size_per_block(v, num_blocks);
+  auto gpu_v = battery::make_unique<mvector, battery::managed_allocator>(v);
+  size_t shared_mem_capacity = max_shared_mem();
+  if(shared_mem_capacity > chunk_size_bytes) {
+    printf("GPU execution with shared memory (%zu/%zu bytes) and %zu blocks.\n", chunk_size_bytes, shared_mem_capacity, num_blocks);
+    map_kernel_shared<<<num_blocks, 256, chunk_size_bytes>>>(gpu_v.get(), chunk_size_bytes);
+  }
+  else {
+    printf("GPU execution with global memory with %zu blocks.\n", num_blocks);
+    map_kernel<<<num_blocks, 256>>>(gpu_v.get());
+  }
+  GPU_SYNC();
+  // Transferring the new data to the initial vector.
+  for(int i = 0; i < (int)v.size(); ++i) {
+    v[i] = (*gpu_v)[i];
+  }
+}
+
+/** Just for comparison with the parallel GPU version. */
+void map_cpu(std::vector<int>& v) {
+  printf("Computing on CPU.\n");
+  block_par_map(v, [](int x) { return x * 2; });
+}
+
+int main(int argc, char** argv) {
+  if(! ((argc == 3 && argv[1] == std::string("cpu"))
+    || (argc == 4 && argv[1] == std::string("gpu"))))
+  {
+    printf("usage: %s <cpu|gpu> <size> [num-blocks]\n", argv[0]);
+    exit(1);
+  }
+  size_t size = std::stol(argv[2]);
+  std::vector<int> original(size, 50);
+  std::vector<int> v(original);
+  if(argv[1] == std::string("cpu")) {
+    map_cpu(v);
+  } else {
+    size_t num_blocks = std::stol(argv[3]);
+    map_gpu(v, num_blocks);
+  }
+  return 0;
+}

--- a/demo/src/inkernel_allocation.cpp
+++ b/demo/src/inkernel_allocation.cpp
@@ -55,7 +55,7 @@ int main() {
       cudaLaunchCooperativeKernel((void*)grid_vector_copy, dimGrid, dimBlock, kernelArgs);
       CUDAEX(cudaDeviceSynchronize());
   } else {
-    std::cout << "Warning: The GPU device does not support launching a CUDA cooperative kernel." << std:endl;
+    std::cout << "Warning: The GPU device does not support launching a CUDA cooperative kernel." << std::endl;
   }
   mvector expected(100000, 42);
   if(expected != *ptr) {

--- a/demo/src/inkernel_allocation_hip.cpp
+++ b/demo/src/inkernel_allocation_hip.cpp
@@ -1,0 +1,97 @@
+// Copyright 2026 Ludovic Temgoua Abanda
+// HIP version of inkernel_allocation.cpp.
+// Compiled as HIP language by CMake when HIP=ON.
+
+#include <vector>
+#include <iostream>
+#include "battery/vector.hpp"
+#include "battery/unique_ptr.hpp"
+#include "battery/allocator.hpp"
+
+// TODO: Remove this alias block once AMD verification is complete.
+// On AMD hardware BATTERY_HIP_BACKEND is always active; inline the HIP calls directly.
+#ifdef BATTERY_CUDA_BACKEND
+  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
+  #define GPU_DEV_ATTR(out, attr, dev) CUDAEX(cudaDeviceGetAttribute(&(out), attr, dev))
+  #define GPU_ATTR_COOP_LAUNCH  cudaDevAttrCooperativeLaunch
+  #define GPU_DEV_GET_LIMIT(val, lim) CUDAE(cudaDeviceGetLimit(val, lim))
+  #define GPU_DEV_SET_LIMIT(lim, val) CUDAE(cudaDeviceSetLimit(lim, val))
+  #define GPU_LIMIT_HEAP  cudaLimitMallocHeapSize
+
+  template<class Fn>
+  void gpu_launch_cooperative(Fn* fn, dim3 grid, dim3 block, void** args) {
+    CUDAEX(cudaLaunchCooperativeKernel((void*)fn, grid, block, args));
+  }
+#elif defined(BATTERY_HIP_BACKEND)
+  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
+  #define GPU_DEV_ATTR(out, attr, dev) HIPEX(hipDeviceGetAttribute(&(out), attr, dev))
+  #define GPU_ATTR_COOP_LAUNCH  hipDevAttrCooperativeLaunch
+  #define GPU_DEV_GET_LIMIT(val, lim) HIPE(hipDeviceGetLimit(val, lim))
+  #define GPU_DEV_SET_LIMIT(lim, val) HIPE(hipDeviceSetLimit(lim, val))
+  #define GPU_LIMIT_HEAP  hipLimitMallocHeapSize
+
+  template<class Fn>
+  void gpu_launch_cooperative(Fn* fn, dim3 grid, dim3 block, void** args) {
+    HIPEX(hipLaunchCooperativeKernel((void*)fn, grid, block, args, 0, nullptr));
+  }
+#endif
+
+/** Different aliases to `vector` with different allocators. */
+using mvector = battery::vector<int, battery::managed_allocator>;
+using gvector = battery::vector<int, battery::global_allocator>;
+
+__global__ void block_vector_copy(mvector* v_ptr) {
+  battery::unique_ptr<gvector, battery::global_allocator> v_block_ptr;
+  gvector& v_block = battery::make_unique_block(v_block_ptr, *v_ptr);
+  // Now each block has its own local copy of the vector `*v_ptr`.
+  v_block[threadIdx.x] += blockIdx.x * threadIdx.x;
+  // We must synchronize the threads at the end, in case the thread holding the pointer in `unique_ptr` terminates before the other.
+  cooperative_groups::this_thread_block().sync(); // Alternatively, `__syncthreads();`
+}
+
+__global__ void grid_vector_copy(mvector* v_ptr) {
+  battery::unique_ptr<gvector, battery::global_allocator> v_copy_ptr;
+  gvector& v_copy = battery::make_unique_grid(v_copy_ptr, *v_ptr);
+  // `v_copy` is now accessible by all blocks.
+  v_copy[blockIdx.x * blockDim.x + threadIdx.x] += blockIdx.x * threadIdx.x;
+  // Same as with block-local memory, we want to guard against destructing the pointer too early.
+  cooperative_groups::this_grid().sync();
+}
+
+void increase_heap_size() {
+  size_t max_heap_size;
+  GPU_DEV_GET_LIMIT(&max_heap_size, GPU_LIMIT_HEAP);
+  GPU_DEV_SET_LIMIT(GPU_LIMIT_HEAP, max_heap_size * 10);
+  GPU_DEV_GET_LIMIT(&max_heap_size, GPU_LIMIT_HEAP);
+  printf("%%GPU_max_heap_size=%zu (%zuMB)\n", max_heap_size, max_heap_size / 1000 / 1000);
+}
+
+int main() {
+  increase_heap_size();
+  auto vptr = battery::make_unique<mvector, battery::managed_allocator>(100000, 42);
+  auto ptr = vptr.get();
+
+  block_vector_copy<<<256, 256>>>(ptr);
+  GPU_SYNC();
+
+  int dev = 0;
+  int supportsCoopLaunch = 0;
+  GPU_DEV_ATTR(supportsCoopLaunch, GPU_ATTR_COOP_LAUNCH, dev);
+  if(supportsCoopLaunch) {
+    void *kernelArgs[] = { &ptr };
+    dim3 dimBlock(256, 1, 1);
+    dim3 dimGrid(256, 1, 1);
+    gpu_launch_cooperative(grid_vector_copy, dimGrid, dimBlock, kernelArgs);
+    GPU_SYNC();
+  } else {
+    std::cout << "Warning: The GPU device does not support launching a cooperative kernel." << std::endl;
+  }
+
+  mvector expected(100000, 42);
+  if(expected != *ptr) {
+    std::cout << "Error: the vector was modified by the kernel." << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/demo/src/inkernel_allocation_hip.cpp
+++ b/demo/src/inkernel_allocation_hip.cpp
@@ -8,34 +8,6 @@
 #include "battery/unique_ptr.hpp"
 #include "battery/allocator.hpp"
 
-// TODO: Remove this alias block once AMD verification is complete.
-// On AMD hardware BATTERY_HIP_BACKEND is always active; inline the HIP calls directly.
-#ifdef BATTERY_CUDA_BACKEND
-  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
-  #define GPU_DEV_ATTR(out, attr, dev) CUDAEX(cudaDeviceGetAttribute(&(out), attr, dev))
-  #define GPU_ATTR_COOP_LAUNCH  cudaDevAttrCooperativeLaunch
-  #define GPU_DEV_GET_LIMIT(val, lim) CUDAE(cudaDeviceGetLimit(val, lim))
-  #define GPU_DEV_SET_LIMIT(lim, val) CUDAE(cudaDeviceSetLimit(lim, val))
-  #define GPU_LIMIT_HEAP  cudaLimitMallocHeapSize
-
-  template<class Fn>
-  void gpu_launch_cooperative(Fn* fn, dim3 grid, dim3 block, void** args) {
-    CUDAEX(cudaLaunchCooperativeKernel((void*)fn, grid, block, args));
-  }
-#elif defined(BATTERY_HIP_BACKEND)
-  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
-  #define GPU_DEV_ATTR(out, attr, dev) HIPEX(hipDeviceGetAttribute(&(out), attr, dev))
-  #define GPU_ATTR_COOP_LAUNCH  hipDevAttrCooperativeLaunch
-  #define GPU_DEV_GET_LIMIT(val, lim) HIPE(hipDeviceGetLimit(val, lim))
-  #define GPU_DEV_SET_LIMIT(lim, val) HIPE(hipDeviceSetLimit(lim, val))
-  #define GPU_LIMIT_HEAP  hipLimitMallocHeapSize
-
-  template<class Fn>
-  void gpu_launch_cooperative(Fn* fn, dim3 grid, dim3 block, void** args) {
-    HIPEX(hipLaunchCooperativeKernel((void*)fn, grid, block, args, 0, nullptr));
-  }
-#endif
-
 /** Different aliases to `vector` with different allocators. */
 using mvector = battery::vector<int, battery::managed_allocator>;
 using gvector = battery::vector<int, battery::global_allocator>;
@@ -60,9 +32,9 @@ __global__ void grid_vector_copy(mvector* v_ptr) {
 
 void increase_heap_size() {
   size_t max_heap_size;
-  GPU_DEV_GET_LIMIT(&max_heap_size, GPU_LIMIT_HEAP);
-  GPU_DEV_SET_LIMIT(GPU_LIMIT_HEAP, max_heap_size * 10);
-  GPU_DEV_GET_LIMIT(&max_heap_size, GPU_LIMIT_HEAP);
+  HIPE(hipDeviceGetLimit(&max_heap_size, hipLimitMallocHeapSize));
+  HIPE(hipDeviceSetLimit(hipLimitMallocHeapSize, max_heap_size * 10));
+  HIPE(hipDeviceGetLimit(&max_heap_size, hipLimitMallocHeapSize));
   printf("%%GPU_max_heap_size=%zu (%zuMB)\n", max_heap_size, max_heap_size / 1000 / 1000);
 }
 
@@ -72,17 +44,17 @@ int main() {
   auto ptr = vptr.get();
 
   block_vector_copy<<<256, 256>>>(ptr);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
 
   int dev = 0;
   int supportsCoopLaunch = 0;
-  GPU_DEV_ATTR(supportsCoopLaunch, GPU_ATTR_COOP_LAUNCH, dev);
+  HIPEX(hipDeviceGetAttribute(&supportsCoopLaunch, hipDeviceAttributeCooperativeLaunch, dev));
   if(supportsCoopLaunch) {
     void *kernelArgs[] = { &ptr };
     dim3 dimBlock(256, 1, 1);
     dim3 dimGrid(256, 1, 1);
-    gpu_launch_cooperative(grid_vector_copy, dimGrid, dimBlock, kernelArgs);
-    GPU_SYNC();
+    HIPEX(hipLaunchCooperativeKernel((void*)grid_vector_copy, dimGrid, dimBlock, kernelArgs, 0, nullptr));
+    HIPEX(hipDeviceSynchronize());
   } else {
     std::cout << "Warning: The GPU device does not support launching a cooperative kernel." << std::endl;
   }

--- a/demo/src/simple_hip.cpp
+++ b/demo/src/simple_hip.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 Ludovic Temgoua Abanda
+// HIP version of simple.cpp.
+// Compiled as HIP language by CMake when HIP=ON.
+
+#include <vector>
+#include "battery/vector.hpp"
+#include "battery/unique_ptr.hpp"
+#include "battery/allocator.hpp"
+
+// TODO: Remove this alias block once AMD verification is complete.
+// On AMD hardware BATTERY_HIP_BACKEND is always active; replace GPU_SYNC()
+// with HIPEX(hipDeviceSynchronize()) directly.
+#ifdef BATTERY_CUDA_BACKEND
+  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
+#elif defined(BATTERY_HIP_BACKEND)
+  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
+#endif
+
+using mvector = battery::vector<int, battery::managed_allocator>;
+
+__global__ void kernel(mvector* v_ptr) {
+  mvector& v = *v_ptr;
+  // ... Compute on `v` in parallel.
+}
+
+int main(int argc, char** argv) {
+  std::vector<int> v(10000, 42);
+  // Transfer from CPU vector to GPU vector.
+  auto gpu_v = battery::make_unique<mvector, battery::managed_allocator>(v);
+  kernel<<<256, 256>>>(gpu_v.get());
+  GPU_SYNC();
+  // Transferring the new data to the initial vector.
+  for(int i = 0; i < (int)v.size(); ++i) {
+    v[i] = (*gpu_v)[i];
+  }
+  return 0;
+}

--- a/demo/src/simple_hip.cpp
+++ b/demo/src/simple_hip.cpp
@@ -7,14 +7,8 @@
 #include "battery/unique_ptr.hpp"
 #include "battery/allocator.hpp"
 
-// TODO: Remove this alias block once AMD verification is complete.
-// On AMD hardware BATTERY_HIP_BACKEND is always active; replace GPU_SYNC()
-// with HIPEX(hipDeviceSynchronize()) directly.
-#ifdef BATTERY_CUDA_BACKEND
-  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
-#elif defined(BATTERY_HIP_BACKEND)
-  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
-#endif
+// Uses the HIP API unconditionally.  On NVIDIA (hip-nvidia-*) BATTERY_HIP_BUILD is set
+// by CMake so hip/hip_runtime.h is in scope; hip* calls map to cuda* via HIP headers.
 
 using mvector = battery::vector<int, battery::managed_allocator>;
 
@@ -28,7 +22,7 @@ int main(int argc, char** argv) {
   // Transfer from CPU vector to GPU vector.
   auto gpu_v = battery::make_unique<mvector, battery::managed_allocator>(v);
   kernel<<<256, 256>>>(gpu_v.get());
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   // Transferring the new data to the initial vector.
   for(int i = 0; i < (int)v.size(); ++i) {
     v[i] = (*gpu_v)[i];

--- a/demo/tests/demo_test_gpu_hip.cpp
+++ b/demo/tests/demo_test_gpu_hip.cpp
@@ -7,14 +7,8 @@
 #include "battery/unique_ptr.hpp"
 #include "battery/allocator.hpp"
 
-// TODO: Remove this alias block once AMD verification is complete.
-// On AMD hardware BATTERY_HIP_BACKEND is always active; replace GPU_SYNC()
-// with HIPEX(hipDeviceSynchronize()) directly.
-#ifdef BATTERY_CUDA_BACKEND
-  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
-#elif defined(BATTERY_HIP_BACKEND)
-  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
-#endif
+// Uses the HIP API unconditionally.  On NVIDIA (hip-nvidia-*) BATTERY_HIP_BUILD is set
+// by CMake so hip/hip_runtime.h is in scope; hip* calls map to cuda* via HIP headers.
 
 using mvector = battery::vector<int, battery::managed_allocator>;
 
@@ -25,7 +19,7 @@ __global__ void map_kernel_test(mvector* v_ptr) {
 void test_with(size_t num_blocks, size_t num_threads) {
   auto gpu_v = battery::make_unique<mvector, battery::managed_allocator>(10000, 50);
   map_kernel_test<<<num_blocks, num_threads>>>(gpu_v.get());
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   for(int i = 0; i < (int)gpu_v->size(); ++i) {
     if((*gpu_v)[i] != 100) {
       printf("Error at index %d: %d != 100\n", i, (*gpu_v)[i]);

--- a/demo/tests/demo_test_gpu_hip.cpp
+++ b/demo/tests/demo_test_gpu_hip.cpp
@@ -1,0 +1,47 @@
+// Copyright 2026 Ludovic Temgoua Abanda
+// HIP version of demo_test_gpu.cpp.
+// Compiled as HIP language by CMake when HIP=ON.
+
+#include "par_map.hpp"
+#include "battery/vector.hpp"
+#include "battery/unique_ptr.hpp"
+#include "battery/allocator.hpp"
+
+// TODO: Remove this alias block once AMD verification is complete.
+// On AMD hardware BATTERY_HIP_BACKEND is always active; replace GPU_SYNC()
+// with HIPEX(hipDeviceSynchronize()) directly.
+#ifdef BATTERY_CUDA_BACKEND
+  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
+#elif defined(BATTERY_HIP_BACKEND)
+  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
+#endif
+
+using mvector = battery::vector<int, battery::managed_allocator>;
+
+__global__ void map_kernel_test(mvector* v_ptr) {
+  grid_par_map(*v_ptr, [](int x){ return x * 2; });
+}
+
+void test_with(size_t num_blocks, size_t num_threads) {
+  auto gpu_v = battery::make_unique<mvector, battery::managed_allocator>(10000, 50);
+  map_kernel_test<<<num_blocks, num_threads>>>(gpu_v.get());
+  GPU_SYNC();
+  for(int i = 0; i < (int)gpu_v->size(); ++i) {
+    if((*gpu_v)[i] != 100) {
+      printf("Error at index %d: %d != 100\n", i, (*gpu_v)[i]);
+      exit(1);
+    }
+  }
+  printf("demo_test_gpu_hip [%zu blocks, %zu threads] succeeded\n", num_blocks, num_threads);
+}
+
+int main() {
+  test_with(1, 1);
+  test_with(1, 256);
+  test_with(256, 1);
+  test_with(50, 100);
+  test_with(100, 100);
+  test_with(100, 101);
+  test_with(256, 256);
+  return 0;
+}

--- a/include/battery/allocator.hpp
+++ b/include/battery/allocator.hpp
@@ -57,42 +57,48 @@ namespace battery { namespace impl {
   NI inline void* gpu_malloc(size_t bytes) {
     if(bytes == 0) return nullptr;
     void* p = nullptr;
-    #ifdef BATTERY_CUDA_BACKEND
+    #if defined(BATTERY_CUDA_BACKEND) && !defined(BATTERY_HIP_BUILD)
       cudaError_t rc = cudaMalloc(&p, bytes);
       if(rc != cudaSuccess)
         std::cerr << "gpu_malloc failed: " << cudaGetErrorString(rc) << std::endl;
-    #else
+    #elif defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)
       hipError_t rc = hipMalloc(&p, bytes);
       if(rc != hipSuccess)
         std::cerr << "gpu_malloc failed: " << hipGetErrorString(rc) << std::endl;
+    #else
+      #error "gpu_malloc: no GPU backend defined (expected BATTERY_CUDA_BACKEND or BATTERY_HIP_BUILD)"
     #endif
     return p;
   }
 
   NI inline void gpu_free(void* p) {
     if(p == nullptr) return;
-    #ifdef BATTERY_CUDA_BACKEND
+    #if defined(BATTERY_CUDA_BACKEND) && !defined(BATTERY_HIP_BUILD)
       cudaError_t rc = cudaFree(p);
       if(rc != cudaSuccess)
         std::cerr << "gpu_free failed: " << cudaGetErrorString(rc) << std::endl;
-    #else
+    #elif defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)
       hipError_t rc = hipFree(p);
       if(rc != hipSuccess)
         std::cerr << "gpu_free failed: " << hipGetErrorString(rc) << std::endl;
+    #else
+      #error "gpu_free: no GPU backend defined (expected BATTERY_CUDA_BACKEND or BATTERY_HIP_BUILD)"
     #endif
   }
 
   NI inline void* gpu_malloc_managed(size_t bytes) {
     if(bytes == 0) return nullptr;
     void* p = nullptr;
-    #ifdef BATTERY_CUDA_BACKEND
+    #if defined(BATTERY_CUDA_BACKEND) && !defined(BATTERY_HIP_BUILD)
       cudaError_t rc = cudaMallocManaged(&p, bytes);
       if(rc != cudaSuccess)
         std::cerr << "gpu_malloc_managed failed: " << cudaGetErrorString(rc) << std::endl;
-    #else
+    #elif defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)
       hipError_t rc = hipMallocManaged(&p, bytes);
       if(rc != hipSuccess)
         std::cerr << "gpu_malloc_managed failed: " << hipGetErrorString(rc) << std::endl;
+    #else
+      #error "gpu_malloc_managed: no GPU backend defined (expected BATTERY_CUDA_BACKEND or BATTERY_HIP_BUILD)"
     #endif
     return p;
   }
@@ -100,28 +106,32 @@ namespace battery { namespace impl {
   NI inline void* gpu_malloc_host(size_t bytes) {
     if(bytes == 0) return nullptr;
     void* p = nullptr;
-    #ifdef BATTERY_CUDA_BACKEND
+    #if defined(BATTERY_CUDA_BACKEND) && !defined(BATTERY_HIP_BUILD)
       cudaError_t rc = cudaMallocHost(&p, bytes);
       if(rc != cudaSuccess)
         std::cerr << "gpu_malloc_host failed: " << cudaGetErrorString(rc) << std::endl;
-    #else
-      hipError_t rc = hipMallocHost(&p, bytes);
+    #elif defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)
+      hipError_t rc = hipHostMalloc(&p, bytes);
       if(rc != hipSuccess)
         std::cerr << "gpu_malloc_host failed: " << hipGetErrorString(rc) << std::endl;
+    #else
+      #error "gpu_malloc_host: no GPU backend defined (expected BATTERY_CUDA_BACKEND or BATTERY_HIP_BUILD)"
     #endif
     return p;
   }
 
   NI inline void gpu_free_host(void* p) {
     if(p == nullptr) return;
-    #ifdef BATTERY_CUDA_BACKEND
+    #if defined(BATTERY_CUDA_BACKEND) && !defined(BATTERY_HIP_BUILD)
       cudaError_t rc = cudaFreeHost(p);
       if(rc != cudaSuccess)
         std::cerr << "gpu_free_host failed: " << cudaGetErrorString(rc) << std::endl;
-    #else
-      hipError_t rc = hipFreeHost(p);
+    #elif defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)
+      hipError_t rc = hipHostFree(p);
       if(rc != hipSuccess)
         std::cerr << "gpu_free_host failed: " << hipGetErrorString(rc) << std::endl;
+    #else
+      #error "gpu_free_host: no GPU backend defined (expected BATTERY_CUDA_BACKEND or BATTERY_HIP_BUILD)"
     #endif
   }
 

--- a/include/battery/allocator.hpp
+++ b/include/battery/allocator.hpp
@@ -47,13 +47,92 @@ CUDA inline void operator delete(void* ptr, battery::standard_allocator& p) {
   return p.deallocate(ptr);
 }
 
-#ifdef BATTERY_CUDA_BACKEND
+#ifdef BATTERY_GPU_ENABLED
+
+// ── Internal GPU API wrappers (host-side only) ────────────────────────────
+// These dispatch to the CUDA or HIP runtime API at compile time so that the
+// allocator classes above need no backend-specific knowledge.
+namespace battery { namespace impl {
+
+  NI inline void* gpu_malloc(size_t bytes) {
+    if(bytes == 0) return nullptr;
+    void* p = nullptr;
+    #ifdef BATTERY_CUDA_BACKEND
+      cudaError_t rc = cudaMalloc(&p, bytes);
+      if(rc != cudaSuccess)
+        std::cerr << "gpu_malloc failed: " << cudaGetErrorString(rc) << std::endl;
+    #else
+      hipError_t rc = hipMalloc(&p, bytes);
+      if(rc != hipSuccess)
+        std::cerr << "gpu_malloc failed: " << hipGetErrorString(rc) << std::endl;
+    #endif
+    return p;
+  }
+
+  NI inline void gpu_free(void* p) {
+    if(p == nullptr) return;
+    #ifdef BATTERY_CUDA_BACKEND
+      cudaError_t rc = cudaFree(p);
+      if(rc != cudaSuccess)
+        std::cerr << "gpu_free failed: " << cudaGetErrorString(rc) << std::endl;
+    #else
+      hipError_t rc = hipFree(p);
+      if(rc != hipSuccess)
+        std::cerr << "gpu_free failed: " << hipGetErrorString(rc) << std::endl;
+    #endif
+  }
+
+  NI inline void* gpu_malloc_managed(size_t bytes) {
+    if(bytes == 0) return nullptr;
+    void* p = nullptr;
+    #ifdef BATTERY_CUDA_BACKEND
+      cudaError_t rc = cudaMallocManaged(&p, bytes);
+      if(rc != cudaSuccess)
+        std::cerr << "gpu_malloc_managed failed: " << cudaGetErrorString(rc) << std::endl;
+    #else
+      hipError_t rc = hipMallocManaged(&p, bytes);
+      if(rc != hipSuccess)
+        std::cerr << "gpu_malloc_managed failed: " << hipGetErrorString(rc) << std::endl;
+    #endif
+    return p;
+  }
+
+  NI inline void* gpu_malloc_host(size_t bytes) {
+    if(bytes == 0) return nullptr;
+    void* p = nullptr;
+    #ifdef BATTERY_CUDA_BACKEND
+      cudaError_t rc = cudaMallocHost(&p, bytes);
+      if(rc != cudaSuccess)
+        std::cerr << "gpu_malloc_host failed: " << cudaGetErrorString(rc) << std::endl;
+    #else
+      hipError_t rc = hipMallocHost(&p, bytes);
+      if(rc != hipSuccess)
+        std::cerr << "gpu_malloc_host failed: " << hipGetErrorString(rc) << std::endl;
+    #endif
+    return p;
+  }
+
+  NI inline void gpu_free_host(void* p) {
+    if(p == nullptr) return;
+    #ifdef BATTERY_CUDA_BACKEND
+      cudaError_t rc = cudaFreeHost(p);
+      if(rc != cudaSuccess)
+        std::cerr << "gpu_free_host failed: " << cudaGetErrorString(rc) << std::endl;
+    #else
+      hipError_t rc = hipFreeHost(p);
+      if(rc != hipSuccess)
+        std::cerr << "gpu_free_host failed: " << hipGetErrorString(rc) << std::endl;
+    #endif
+  }
+
+}} // namespace battery::impl
 
 namespace battery {
 
-/** An allocator using the global memory of CUDA.
-This can be used from both the host and device side, but the memory can only be accessed when in a device function.
-Beware that allocation and deallocation must occur on the same side. */
+/** An allocator using the device-global memory of the GPU.
+ * This can be used from both the host and device side, but the memory can
+ * only be accessed when in a device function.
+ * Beware that allocation and deallocation must occur on the same side. */
 class global_allocator {
 public:
   CUDA NI void* allocate(size_t bytes) {
@@ -67,13 +146,7 @@ public:
       }
       return data;
     #else
-      void* data = nullptr;
-      cudaError_t rc = cudaMalloc(&data, bytes);
-      if (rc != cudaSuccess) {
-        std::cerr << "Allocation of global memory failed: " << cudaGetErrorString(rc) << std::endl;
-        return nullptr;
-      }
-      return data;
+      return impl::gpu_malloc(bytes);
     #endif
   }
 
@@ -84,17 +157,15 @@ public:
         std::free(data);
       #endif
     #else
-      cudaError_t rc = cudaFree(data);
-      if (rc != cudaSuccess) {
-        std::cerr << "Free of global memory failed: " << cudaGetErrorString(rc) << std::endl;
-      }
+      impl::gpu_free(data);
     #endif
   }
 
   CUDA bool operator==(const global_allocator&) const { return true; }
 };
 
-/** An allocator using the managed memory of CUDA when the memory is allocated on the host. */
+/** An allocator using the managed (unified) memory of the GPU when the
+ * memory is allocated on the host. */
 class managed_allocator {
 public:
   CUDA NI void* allocate(size_t bytes) {
@@ -103,16 +174,7 @@ public:
       assert(false);
       return nullptr;
     #else
-      if(bytes == 0) {
-        return nullptr;
-      }
-      void* data = nullptr;
-      cudaError_t rc = cudaMallocManaged(&data, bytes);
-      if (rc != cudaSuccess) {
-        std::cerr << "Allocation of managed memory failed: " << cudaGetErrorString(rc) << std::endl;
-        return nullptr;
-      }
-      return data;
+      return impl::gpu_malloc_managed(bytes);
     #endif
   }
 
@@ -121,41 +183,32 @@ public:
       printf("Managed memory cannot be freed in device functions.\n");
       assert(false);
     #else
-      cudaError_t rc = cudaFree(data);
-      if (rc != cudaSuccess) {
-        std::cerr << "Free of managed memory failed: " << cudaGetErrorString(rc) << std::endl;
-      }
+      impl::gpu_free(data);
     #endif
   }
 
   CUDA bool operator==(const managed_allocator&) const { return true; }
 };
 
-/** An allocator using pinned memory for shared access between the host and the device.
- * This type of memory is required on Microsoft Windows, on the Windows Subsystem for Linux (WSL), and on NVIDIA GRID (virtual GPU), because these systems do not support concurrent access to managed memory while a CUDA kernel is running.
+/** An allocator using pinned (page-locked) memory for shared access between
+ * the host and the device.
+ * This type of memory is required on Microsoft Windows, on the Windows
+ * Subsystem for Linux (WSL), and on NVIDIA GRID (virtual GPU), because
+ * these systems do not support concurrent access to managed memory while a
+ * GPU kernel is running.
  *
- * This allocator requires that you first set cudaDeviceMapHost using  cudaSetDeviceFlags.
+ * We suppose unified virtual addressing (UVA) is enabled.
  *
- * We suppose unified virtual addressing (UVA) is enabled (the property `unifiedAddressing` is true).
- *
- * We delegate the allocation to `global_allocator` when the allocation is done on the device, since host memory cannot be allocated in device functions.
- * */
+ * We delegate the allocation to `global_allocator` when the allocation is
+ * done on the device, since host memory cannot be allocated in device functions.
+ */
 class pinned_allocator {
 public:
   CUDA NI void* allocate(size_t bytes) {
     #ifdef BATTERY_DEVICE_CODE
       return global_allocator{}.allocate(bytes);
     #else
-      if(bytes == 0) {
-        return nullptr;
-      }
-      void* data = nullptr;
-      cudaError_t rc = cudaMallocHost(&data, bytes); // pinned
-      if (rc != cudaSuccess) {
-        std::cerr << "Allocation of pinned memory failed: " << cudaGetErrorString(rc) << std::endl;
-        return nullptr;
-      }
-      return data;
+      return impl::gpu_malloc_host(bytes);
     #endif
   }
 
@@ -163,10 +216,7 @@ public:
     #ifdef BATTERY_DEVICE_CODE
       return global_allocator{}.deallocate(data);
     #else
-      cudaError_t rc = cudaFreeHost(data);
-      if (rc != cudaSuccess) {
-        std::cerr << "Free of pinned memory failed: " << cudaGetErrorString(rc) << std::endl;
-      }
+      impl::gpu_free_host(data);
     #endif
   }
 
@@ -199,7 +249,7 @@ CUDA inline void operator delete(void* ptr, battery::pinned_allocator& p) {
   p.deallocate(ptr);
 }
 
-#endif // BATTERY_CUDA_BACKEND
+#endif // BATTERY_GPU_ENABLED
 
 namespace battery {
 

--- a/include/battery/allocator.hpp
+++ b/include/battery/allocator.hpp
@@ -47,7 +47,7 @@ CUDA inline void operator delete(void* ptr, battery::standard_allocator& p) {
   return p.deallocate(ptr);
 }
 
-#ifdef __CUDACC__
+#ifdef BATTERY_CUDA_BACKEND
 
 namespace battery {
 
@@ -60,7 +60,7 @@ public:
     if(bytes == 0) {
       return nullptr;
     }
-    #ifdef __CUDA_ARCH__
+    #ifdef BATTERY_DEVICE_CODE
       void* data = std::malloc(bytes);
       if (data == nullptr) {
         printf("Allocation of device memory failed\n");
@@ -78,7 +78,7 @@ public:
   }
 
   CUDA NI void deallocate(void* data) {
-    #ifdef __CUDA_ARCH__
+    #ifdef BATTERY_DEVICE_CODE
       // Bug in Turbo when deleting with free. Couldn't find the reason yet.
       #ifndef CUDA_THREADS_PER_BLOCK
         std::free(data);
@@ -98,7 +98,7 @@ public:
 class managed_allocator {
 public:
   CUDA NI void* allocate(size_t bytes) {
-    #ifdef __CUDA_ARCH__
+    #ifdef BATTERY_DEVICE_CODE
       printf("Managed memory cannot be allocated in device functions.\n");
       assert(false);
       return nullptr;
@@ -117,7 +117,7 @@ public:
   }
 
   CUDA NI void deallocate(void* data) {
-    #ifdef __CUDA_ARCH__
+    #ifdef BATTERY_DEVICE_CODE
       printf("Managed memory cannot be freed in device functions.\n");
       assert(false);
     #else
@@ -143,7 +143,7 @@ public:
 class pinned_allocator {
 public:
   CUDA NI void* allocate(size_t bytes) {
-    #ifdef __CUDA_ARCH__
+    #ifdef BATTERY_DEVICE_CODE
       return global_allocator{}.allocate(bytes);
     #else
       if(bytes == 0) {
@@ -160,7 +160,7 @@ public:
   }
 
   CUDA NI void deallocate(void* data) {
-    #ifdef __CUDA_ARCH__
+    #ifdef BATTERY_DEVICE_CODE
       return global_allocator{}.deallocate(data);
     #else
       cudaError_t rc = cudaFreeHost(data);
@@ -199,12 +199,12 @@ CUDA inline void operator delete(void* ptr, battery::pinned_allocator& p) {
   p.deallocate(ptr);
 }
 
-#endif // __CUDACC__
+#endif // BATTERY_CUDA_BACKEND
 
 namespace battery {
 
 namespace impl {
-#ifdef __CUDA_ARCH__
+#ifdef BATTERY_DEVICE_CODE
   __constant__
 #endif
 static const int power2[17] = {0, 1, 2, 2, 4, 4, 4, 4, 8, 8, 8, 8, 8, 8, 8, 8, 16};

--- a/include/battery/allocator.hpp
+++ b/include/battery/allocator.hpp
@@ -49,7 +49,7 @@ CUDA inline void operator delete(void* ptr, battery::standard_allocator& p) {
 
 #ifdef BATTERY_GPU_ENABLED
 
-// ── Internal GPU API wrappers (host-side only) ────────────────────────────
+// -- Internal GPU API wrappers (host-side only) ----------------------------
 // These dispatch to the CUDA or HIP runtime API at compile time so that the
 // allocator classes above need no backend-specific knowledge.
 namespace battery { namespace impl {

--- a/include/battery/memory.hpp
+++ b/include/battery/memory.hpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <type_traits>
 #include <utility>
+#include "utility.hpp"
 
 #ifdef BATTERY_CUDA_BACKEND
   #include <cuda/atomic>
@@ -20,8 +21,6 @@
 #else
   #include <atomic>
 #endif
-
-#include "utility.hpp"
 
 namespace battery {
 

--- a/include/battery/memory.hpp
+++ b/include/battery/memory.hpp
@@ -14,6 +14,9 @@
 
 #ifdef BATTERY_CUDA_BACKEND
   #include <cuda/atomic>
+#elif defined(BATTERY_HIP_BACKEND)
+  #include <hip/hip_runtime.h>
+  #include <atomic>
 #else
   #include <atomic>
 #endif
@@ -34,6 +37,37 @@ namespace impl {
     using type = V;
   };
 #endif
+
+#ifdef BATTERY_HIP_BACKEND
+  /** HIP scope constants mapping to __HIP_MEMORY_SCOPE_* values. */
+  constexpr int hip_scope_block      = __HIP_MEMORY_SCOPE_WORKGROUP;
+  constexpr int hip_scope_device     = __HIP_MEMORY_SCOPE_AGENT;
+  constexpr int hip_scope_system     = __HIP_MEMORY_SCOPE_SYSTEM;
+
+  /**
+   * Thin wrapper around __hip_atomic_* intrinsics that mirrors the
+   * cuda::atomic<V, Scope> interface expected by copyable_atomic.
+   * Works in both host and device code under hipcc.
+   */
+  template <class T, int Scope>
+  class hip_atomic_wrapper {
+    T value_;
+  public:
+    using value_type = T;
+    CUDA hip_atomic_wrapper() = default;
+    CUDA hip_atomic_wrapper(T v) : value_(v) {}
+
+    CUDA T load(int order = __ATOMIC_RELAXED) const {
+      return __hip_atomic_load(&value_, order, Scope);
+    }
+    CUDA void store(T v, int order = __ATOMIC_RELAXED) {
+      __hip_atomic_store(&value_, v, order, Scope);
+    }
+    CUDA T exchange(T v, int order = __ATOMIC_RELAXED) {
+      return __hip_atomic_exchange(&value_, v, order, Scope);
+    }
+  };
+#endif // BATTERY_HIP_BACKEND
 }
 
 
@@ -114,6 +148,41 @@ using atomic_memory_grid = atomic_memory_scoped<cuda::thread_scope_device>;
 using atomic_memory_multi_grid = atomic_memory_scoped<cuda::thread_scope_system>;
 
 #endif // BATTERY_CUDA_BACKEND
+
+#ifdef BATTERY_HIP_BACKEND
+
+/** Memory load and store operations with an explicit HIP memory scope and
+ *  a given memory order (relaxed by default).
+ *  The Scope template parameter uses the __HIP_MEMORY_SCOPE_* integer constants,
+ *  exposed through battery::impl::hip_scope_{block,device,system}.
+ */
+template <int Scope, int mem_order = __ATOMIC_RELAXED>
+class atomic_memory_scoped {
+public:
+  template <class T> using atomic_type = copyable_atomic<impl::hip_atomic_wrapper<T, Scope>>;
+  constexpr static const bool sequential = false;
+
+  template <class T>
+  CUDA INLINE static T load(const atomic_type<T>& a) {
+    return a.load(mem_order);
+  }
+
+  template <class T>
+  CUDA INLINE static void store(atomic_type<T>& a, T v) {
+    a.store(v, mem_order);
+  }
+
+  template <class T>
+  CUDA INLINE static T exchange(atomic_type<T>& a, T v) {
+    return a.exchange(v, mem_order);
+  }
+};
+
+using atomic_memory_block      = atomic_memory_scoped<impl::hip_scope_block>;
+using atomic_memory_grid       = atomic_memory_scoped<impl::hip_scope_device>;
+using atomic_memory_multi_grid = atomic_memory_scoped<impl::hip_scope_system>;
+
+#endif // BATTERY_HIP_BACKEND
 
 #ifdef BATTERY_CUDA_BACKEND
   /// @private

--- a/include/battery/memory.hpp
+++ b/include/battery/memory.hpp
@@ -12,7 +12,7 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef __CUDACC__
+#ifdef BATTERY_CUDA_BACKEND
   #include <cuda/atomic>
 #else
   #include <atomic>
@@ -28,7 +28,7 @@ namespace impl {
   struct value_type_of {
     using type = typename T::value_type;
   };
-#ifdef __CUDACC__
+#ifdef BATTERY_CUDA_BACKEND
   template <class V, cuda::thread_scope Scope>
   struct value_type_of<cuda::atomic<V, Scope>> {
     using type = V;
@@ -84,7 +84,7 @@ public:
 using local_memory = memory<false>;
 using read_only_memory = memory<true>;
 
-#ifdef __CUDACC__
+#ifdef BATTERY_CUDA_BACKEND
 
 /** Memory load and store operations relative to a cuda scope (per-thread, block, grid, ...) and given a certain memory order (by default relaxed). */
 template <cuda::thread_scope scope, cuda::memory_order mem_order = cuda::memory_order_relaxed>
@@ -113,9 +113,9 @@ using atomic_memory_block = atomic_memory_scoped<cuda::thread_scope_block>;
 using atomic_memory_grid = atomic_memory_scoped<cuda::thread_scope_device>;
 using atomic_memory_multi_grid = atomic_memory_scoped<cuda::thread_scope_system>;
 
-#endif // __CUDACC__
+#endif // BATTERY_CUDA_BACKEND
 
-#ifdef __CUDACC__
+#ifdef BATTERY_CUDA_BACKEND
   /// @private
   namespace impl {
     template <class T>

--- a/include/battery/unique_ptr.hpp
+++ b/include/battery/unique_ptr.hpp
@@ -118,7 +118,7 @@ template<class T, class Alloc, class... Args>
 CUDA NI unique_ptr<T, Alloc> allocate_unique(const Alloc& alloc, Args&&... args) {
   Alloc allocator(alloc);
   T* ptr = static_cast<T*>(allocator.allocate(sizeof(T)));
-  assert(ptr != nullptr);
+  assert(ptr); // avoid __nv_bool/nullptr_t clash when HIP headers are included with nvcc
   if constexpr(std::is_constructible<T, Args&&..., const Alloc&>{}) {
     new(ptr) T(std::forward<Args>(args)..., allocator);
   }
@@ -138,15 +138,18 @@ CUDA unique_ptr<T, Alloc> make_unique(Args&&... args) {
 
 }
 
-#ifdef BATTERY_CUDA_BACKEND
-  #include <cooperative_groups.h>
-#elif defined(BATTERY_HIP_BACKEND)
+// On hip-nvidia (BATTERY_HIP_BUILD, nvcc compiler): use <hip/hip_cooperative_groups.h> so
+// that cooperative_groups::this_grid() is the HIP variant.  On BATTERY_CUDA_BACKEND without
+// HIP build: use the standard CUDA CG header.  On BATTERY_HIP_BACKEND (AMD hipcc): HIP CG.
+#if defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)
   #include <hip/hip_cooperative_groups.h>
+#else
+  #include <cooperative_groups.h>
 #endif
 
 namespace battery {
 
-#ifdef BATTERY_HIP_BACKEND
+#if defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)
   /** HIP's cooperative_groups does not ship `invoke_one`.
    *  This shim executes the callable on exactly one thread (rank 0) of the group,
    *  mirroring the semantics of `cooperative_groups::invoke_one` from CUDA.

--- a/include/battery/unique_ptr.hpp
+++ b/include/battery/unique_ptr.hpp
@@ -134,7 +134,7 @@ CUDA unique_ptr<T, Alloc> make_unique(Args&&... args) {
   return allocate_unique<T>(Alloc(), std::forward<Args>(args)...);
 }
 
-#ifdef __CUDACC__
+#ifdef BATTERY_CUDA_BACKEND
 
 }
 

--- a/include/battery/unique_ptr.hpp
+++ b/include/battery/unique_ptr.hpp
@@ -134,13 +134,28 @@ CUDA unique_ptr<T, Alloc> make_unique(Args&&... args) {
   return allocate_unique<T>(Alloc(), std::forward<Args>(args)...);
 }
 
-#ifdef BATTERY_CUDA_BACKEND
+#ifdef BATTERY_GPU_ENABLED
 
 }
 
-#include <cooperative_groups.h>
+#ifdef BATTERY_CUDA_BACKEND
+  #include <cooperative_groups.h>
+#elif defined(BATTERY_HIP_BACKEND)
+  #include <hip/hip_cooperative_groups.h>
+#endif
 
 namespace battery {
+
+#ifdef BATTERY_HIP_BACKEND
+  /** HIP's cooperative_groups does not ship `invoke_one`.
+   *  This shim executes the callable on exactly one thread (rank 0) of the group,
+   *  mirroring the semantics of `cooperative_groups::invoke_one` from CUDA.
+   */
+  template<class Group, class Callable>
+  __device__ INLINE void invoke_one(Group& g, Callable&& f) {
+    if(g.thread_rank() == 0) std::forward<Callable>(f)();
+  }
+#endif
 
 /** We construct a `unique_ptr` in the style of `allocate_unique` but the function is allowed to be entered by all threads of a block.
  * Only one thread of the block will call the function `allocate_unique`.
@@ -157,7 +172,7 @@ namespace battery {
  * block.sync(); // or __syncthreads();
  * ```
  *
- * NOTE: this function use the cooperative groups library.
+ * NOTE: this function uses the cooperative groups library.
  */
 template<class T, class Alloc, class... Args>
 __device__ NI T& make_unique_block(unique_ptr<T, Alloc>& ptr, Args&&... args) {
@@ -180,7 +195,9 @@ namespace impl {
 }
 
 /** Same as `make_unique_block` but for the grid (all blocks).
- * NOTE: a kernel using this function must be launched using `cudaLaunchCooperativeKernel` instead of the `<<<...>>>` syntax.
+ * NOTE: a kernel using this function must be launched using the cooperative launch API
+ *       (`cudaLaunchCooperativeKernel` on CUDA, `hipLaunchCooperativeKernel` on HIP)
+ *       instead of the `<<<...>>>` syntax.
  */
 template<class T, class Alloc, class... Args>
 __device__ NI T& make_unique_grid(unique_ptr<T, Alloc>& ptr, Args&&... args) {
@@ -196,7 +213,7 @@ __device__ NI T& make_unique_grid(unique_ptr<T, Alloc>& ptr, Args&&... args) {
   return *data_ptr;
 }
 
-#endif
+#endif // BATTERY_GPU_ENABLED
 
 } // namespace battery
 

--- a/include/battery/utility.hpp
+++ b/include/battery/utility.hpp
@@ -13,11 +13,33 @@
 #include <cfenv>
 #include <bit>
 
-#ifdef __CUDACC__
+// ── Backend detection ─────────────────────────────────────────────────────
+/** Defined when compiling with any GPU compiler (nvcc or hipcc). */
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  #define BATTERY_GPU_ENABLED
+#endif
+
+/** Defined when compiling device function bodies. */
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  #define BATTERY_DEVICE_CODE
+#endif
+
+/** Defined when compiling with nvcc (pure CUDA backend, not via HIP). */
+#if defined(__CUDACC__) && !defined(__HIPCC__)
+  #define BATTERY_CUDA_BACKEND
+#endif
+
+/** Defined when compiling with hipcc (AMD ROCm or NVIDIA via HIP). */
+#ifdef __HIPCC__
+  #define BATTERY_HIP_BACKEND
+#endif
+
+// ── GPU qualifiers (identical in CUDA and HIP) ────────────────────────────
+#ifdef BATTERY_GPU_ENABLED
   #define CUDA_GLOBAL __global__
 
   #ifdef REDUCE_PTX_SIZE
-    /** `NI` stands for noinline, to hint `nvcc` the function should not be inlined. */
+    /** `NI` stands for noinline, to hint the GPU compiler the function should not be inlined. */
     #define NI __noinline__
   #else
     #define NI
@@ -26,42 +48,74 @@
   /** Request a function to be inlined. */
   #define INLINE __forceinline__
 
-  /** `CUDA` is a macro indicating that a function can be executed on a GPU. It is defined to `__device__ __host__` when the code is compiled with `nvcc`. */
+  /** `CUDA` is a macro indicating that a function can be executed on a GPU. It is defined to `__device__ __host__` when the code is compiled with a GPU compiler. */
   #define CUDA __device__ __host__
 
-  namespace battery {
-  namespace impl {
-    CUDA NI inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true) {
-      if (code != cudaSuccess) {
-        printf("%s:%d CUDA runtime error %s\n", file, line, cudaGetErrorString(code));
-        if (abort) {
-          #ifdef __CUDA_ARCH__
-            assert(0);
-          #else
-            exit(code);
-          #endif
+  // ── CUDA error-check macros ──────────────────────────────────────────────
+  #ifdef BATTERY_CUDA_BACKEND
+    namespace battery {
+    namespace impl {
+      CUDA NI inline void cudaAssert(cudaError_t code, const char *file, int line, bool abort=true) {
+        if (code != cudaSuccess) {
+          printf("%s:%d CUDA runtime error %s\n", file, line, cudaGetErrorString(code));
+          if (abort) {
+            #ifdef BATTERY_DEVICE_CODE
+              assert(0);
+            #else
+              exit(code);
+            #endif
+          }
         }
       }
-    }
-  }}
+    }}
 
-  /** A macro checking the result of a CUDA API call.
-   * It prints an error message if an error occured.
-  */
-  #define CUDAE(result) { ::battery::impl::gpuAssert((result), __FILE__, __LINE__, false); }
+    /** A macro checking the result of a CUDA API call.
+     * It prints an error message if an error occured.
+    */
+    #define CUDAE(result) { ::battery::impl::cudaAssert((result), __FILE__, __LINE__, false); }
 
-  /** Similar to CUDAE but abort the computation in addition, either with `assert` (GPU) or `exit` (CPU).
-  */
-  #define CUDAEX(result) { ::battery::impl::gpuAssert((result), __FILE__, __LINE__, true); }
+    /** Similar to CUDAE but abort the computation in addition, either with `assert` (GPU) or `exit` (CPU).
+    */
+    #define CUDAEX(result) { ::battery::impl::cudaAssert((result), __FILE__, __LINE__, true); }
 
-#else
+  // ── HIP error-check macros ───────────────────────────────────────────────
+  #elif defined(BATTERY_HIP_BACKEND)
+    #include <hip/hip_runtime.h>
+    namespace battery {
+    namespace impl {
+      CUDA NI inline void hipAssert(hipError_t code, const char *file, int line, bool abort=true) {
+        if (code != hipSuccess) {
+          printf("%s:%d HIP runtime error %s\n", file, line, hipGetErrorString(code));
+          if (abort) {
+            #ifdef BATTERY_DEVICE_CODE
+              assert(0);
+            #else
+              exit(code);
+            #endif
+          }
+        }
+      }
+    }}
+
+    /** A macro checking the result of a HIP API call.
+     * It prints an error message if an error occured.
+    */
+    #define HIPE(result) { ::battery::impl::hipAssert((result), __FILE__, __LINE__, false); }
+
+    /** Similar to HIPE but abort the computation in addition, either with `assert` (GPU) or `exit` (CPU).
+    */
+    #define HIPEX(result) { ::battery::impl::hipAssert((result), __FILE__, __LINE__, true); }
+
+  #endif // BATTERY_CUDA_BACKEND / BATTERY_HIP_BACKEND
+
+#else // !BATTERY_GPU_ENABLED (CPU only)
   #define CUDA_GLOBAL
   #define CUDA
   #define CUDAE(S) S
   #define CUDAEX(S) S
   #define NI
   #define INLINE inline
-#endif
+#endif // BATTERY_GPU_ENABLED
 
 namespace battery {
 
@@ -89,7 +143,7 @@ namespace impl {
 }
 
 template<class T> CUDA constexpr inline void swap(T& a, T& b) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     impl::swap(a, b);
   #else
     std::swap(a, b);
@@ -97,7 +151,7 @@ template<class T> CUDA constexpr inline void swap(T& a, T& b) {
 }
 
 CUDA inline size_t strlen(const char* str) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     return impl::strlen(str);
   #else
     return std::strlen(str);
@@ -106,7 +160,7 @@ CUDA inline size_t strlen(const char* str) {
 
 /** See https://stackoverflow.com/a/34873406/2231159 */
 CUDA inline int strcmp(const char* s1, const char* s2) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     return impl::strcmp(s1, s2);
   #else
     return std::strcmp(s1, s2);
@@ -114,7 +168,7 @@ CUDA inline int strcmp(const char* s1, const char* s2) {
 }
 
 template<class T> CUDA INLINE constexpr T min(T a, T b) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     // When C++23 is available
     // if !consteval { return ::min(a, b); }
     // else { return std::min(a, b); }
@@ -126,7 +180,7 @@ template<class T> CUDA INLINE constexpr T min(T a, T b) {
 }
 
 template<class T> CUDA INLINE constexpr T max(T a, T b) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     // When C++23 is available
     // if !consteval { return ::max(a, b); }
     // else { return std::max(a, b); }
@@ -138,7 +192,7 @@ template<class T> CUDA INLINE constexpr T max(T a, T b) {
 }
 
 template<class T> CUDA constexpr T isnan(T a) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     return ::isnan(a);
   #else
     return std::isnan(a);
@@ -146,7 +200,7 @@ template<class T> CUDA constexpr T isnan(T a) {
 }
 
 CUDA constexpr double pow(double a, double b) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     return ::pow(a, b);
   #else
     return std::pow(a, b);
@@ -161,7 +215,7 @@ CUDA constexpr double pow(double a, double b) {
 #endif
 
 CUDA CONSTEXPR_NEXTAFTER inline float nextafter(float f, float dir) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     return ::nextafterf(f, dir);
   #else
     return std::nextafterf(f, dir);
@@ -169,7 +223,7 @@ CUDA CONSTEXPR_NEXTAFTER inline float nextafter(float f, float dir) {
 }
 
 CUDA CONSTEXPR_NEXTAFTER inline double nextafter(double f, double dir) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     return ::nextafter(f, dir);
   #else
     return std::nextafter(f, dir);
@@ -221,7 +275,7 @@ CUDA NI constexpr To ru_cast(From x) {
   if constexpr(map_limits) {
     MAP_LIMITS(x, From, To)
   }
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     // Integer to floating-point number cast.
     if constexpr(std::is_integral_v<From> && std::is_floating_point_v<To>) {
       if constexpr(std::is_same_v<From, unsigned long long>) {
@@ -317,7 +371,7 @@ CUDA NI constexpr To rd_cast(From x) {
   if constexpr(map_limits) {
     MAP_LIMITS(x, From, To)
   }
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     // Integer to floating-point number cast.
     if constexpr(std::is_integral_v<From> && std::is_floating_point_v<To>) {
       if constexpr(std::is_same_v<From, unsigned long long>) {
@@ -401,7 +455,7 @@ CUDA NI constexpr To rd_cast(From x) {
 template<class T>
 CUDA NI constexpr int popcount(T x) {
   static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "popcount only works on unsigned integers");
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     if constexpr(std::is_same_v<T, unsigned int>) {
       return __popc(x);
     }
@@ -426,7 +480,7 @@ CUDA NI constexpr int popcount(T x) {
 template<class T>
 CUDA NI constexpr int countl_zero(T x) {
   static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "countl_zero only works on unsigned integers");
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     // If the size of `T` is smaller than `int` or `long long int` we must remove the extra zeroes that are added after conversion.
     if constexpr(sizeof(T) <= sizeof(int)) {
       return __clz(x) - ((sizeof(int) - sizeof(T)) * CHAR_BIT);
@@ -454,7 +508,7 @@ CUDA NI constexpr int countl_zero(T x) {
 template<class T>
 CUDA NI constexpr int countl_one(T x) {
   static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "countl_one only works on unsigned integers");
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     return countl_zero((T)~x);
   #elif __cpp_lib_bitops
     return std::countl_one(x);
@@ -473,7 +527,7 @@ CUDA NI constexpr int countl_one(T x) {
 template<class T>
 CUDA NI constexpr int countr_zero(T x) {
   static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "countl_zero only works on unsigned integers");
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     if(x == 0) {
       return sizeof(T) * CHAR_BIT;
     }
@@ -503,7 +557,7 @@ CUDA NI constexpr int countr_zero(T x) {
 template<class T>
 CUDA NI constexpr int countr_one(T x) {
   static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "countr_one only works on unsigned integers");
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     return countr_zero((T)~x);
   #elif __cpp_lib_bitops
     return std::countr_one(x);
@@ -582,7 +636,7 @@ CUDA T iroots_up(T x, int r) {
 
 template <class T>
 CUDA constexpr T add_up(T x, T y) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     FLOAT_ARITHMETIC_CUDA_IMPL(add_up, add_ru)
   #else
     #if !defined(__GNUC__) && !defined(_MSC_VER)
@@ -594,7 +648,7 @@ CUDA constexpr T add_up(T x, T y) {
 
 template <class T>
 CUDA constexpr T add_down(T x, T y) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     FLOAT_ARITHMETIC_CUDA_IMPL(add_down, add_rd)
   #else
     #if !defined(__GNUC__) && !defined(_MSC_VER)
@@ -606,7 +660,7 @@ CUDA constexpr T add_down(T x, T y) {
 
 template <class T>
 CUDA constexpr T sub_up(T x, T y) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     FLOAT_ARITHMETIC_CUDA_IMPL(sub_up, sub_ru)
   #else
     #if !defined(__GNUC__) && !defined(_MSC_VER)
@@ -618,7 +672,7 @@ CUDA constexpr T sub_up(T x, T y) {
 
 template <class T>
 CUDA constexpr T sub_down(T x, T y) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     FLOAT_ARITHMETIC_CUDA_IMPL(sub_down, sub_rd)
   #else
     #if !defined(__GNUC__) && !defined(_MSC_VER)
@@ -630,7 +684,7 @@ CUDA constexpr T sub_down(T x, T y) {
 
 template <class T>
 CUDA constexpr T mul_up(T x, T y) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     FLOAT_ARITHMETIC_CUDA_IMPL(mul_up, mul_ru)
   #else
     #if !defined(__GNUC__) && !defined(_MSC_VER)
@@ -642,7 +696,7 @@ CUDA constexpr T mul_up(T x, T y) {
 
 template <class T>
 CUDA constexpr T mul_down(T x, T y) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     FLOAT_ARITHMETIC_CUDA_IMPL(mul_down, mul_rd)
   #else
     #if !defined(__GNUC__) && !defined(_MSC_VER)
@@ -654,7 +708,7 @@ CUDA constexpr T mul_down(T x, T y) {
 
 template <class T>
 CUDA constexpr T div_up(T x, T y) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     FLOAT_ARITHMETIC_CUDA_IMPL(div_up, div_ru)
   #else
     #if !defined(__GNUC__) && !defined(_MSC_VER)
@@ -666,7 +720,7 @@ CUDA constexpr T div_up(T x, T y) {
 
 template <class T>
 CUDA constexpr T div_down(T x, T y) {
-  #ifdef __CUDA_ARCH__
+  #ifdef BATTERY_DEVICE_CODE
     FLOAT_ARITHMETIC_CUDA_IMPL(div_down, div_rd)
   #else
     #if !defined(__GNUC__) && !defined(_MSC_VER)

--- a/include/battery/utility.hpp
+++ b/include/battery/utility.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Pierre Talbot, Frédéric Pinel
+// Copyright 2021 Pierre Talbot, Frédéric Pinel, Ludovic Temgoua Abanda
 
 #ifndef CUDA_BATTERY_UTILITY_HPP
 #define CUDA_BATTERY_UTILITY_HPP
@@ -13,7 +13,7 @@
 #include <cfenv>
 #include <bit>
 
-// ── Backend detection ─────────────────────────────────────────────────────
+// -- Backend detection -----------------------------------------------------
 /** Defined when compiling with any GPU compiler (nvcc or hipcc). */
 #if defined(__CUDACC__) || defined(__HIPCC__)
   #define BATTERY_GPU_ENABLED
@@ -34,7 +34,7 @@
   #define BATTERY_HIP_BACKEND
 #endif
 
-// ── GPU qualifiers (identical in CUDA and HIP) ────────────────────────────
+// -- GPU qualifiers (identical in CUDA and HIP) ----------------------------
 #ifdef BATTERY_GPU_ENABLED
   #define CUDA_GLOBAL __global__
 
@@ -51,7 +51,7 @@
   /** `CUDA` is a macro indicating that a function can be executed on a GPU. It is defined to `__device__ __host__` when the code is compiled with a GPU compiler. */
   #define CUDA __device__ __host__
 
-  // ── CUDA error-check macros ──────────────────────────────────────────────
+  // -- CUDA error-check macros ----------------------------------------------
   #ifdef BATTERY_CUDA_BACKEND
     namespace battery {
     namespace impl {
@@ -79,7 +79,7 @@
     #define CUDAEX(result) { ::battery::impl::cudaAssert((result), __FILE__, __LINE__, true); }
   #endif // BATTERY_CUDA_BACKEND
 
-  // ── HIP error-check macros ───────────────────────────────────────────────
+  // -- HIP error-check macros -----------------------------------------------
   // Available when: (a) compiled with hipcc (AMD native), or
   //                 (b) compiled with nvcc under a HIP=ON CMake build
   //                     (hip-nvidia-* presets: ROCm headers are in scope,

--- a/include/battery/utility.hpp
+++ b/include/battery/utility.hpp
@@ -77,13 +77,23 @@
     /** Similar to CUDAE but abort the computation in addition, either with `assert` (GPU) or `exit` (CPU).
     */
     #define CUDAEX(result) { ::battery::impl::cudaAssert((result), __FILE__, __LINE__, true); }
+  #endif // BATTERY_CUDA_BACKEND
 
   // ── HIP error-check macros ───────────────────────────────────────────────
-  #elif defined(BATTERY_HIP_BACKEND)
+  // Available when: (a) compiled with hipcc (AMD native), or
+  //                 (b) compiled with nvcc under a HIP=ON CMake build
+  //                     (hip-nvidia-* presets: ROCm headers are in scope,
+  //                      hip/hip_runtime.h maps all hip* calls to cuda* calls).
+  // BATTERY_HIP_BUILD is set for all HIP builds (AMD and hip-nvidia).
+  // <hip/hip_runtime.h> is safe here because unique_ptr.hpp uses
+  // <hip/hip_cooperative_groups.h> (not CUDA's <cooperative_groups.h>) when
+  // BATTERY_HIP_BUILD is set — the ROCm CG header is designed to coexist with
+  // <hip/hip_runtime.h>, avoiding the __nv_bool redefinition conflict.
+  #if defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)
     #include <hip/hip_runtime.h>
     namespace battery {
     namespace impl {
-      CUDA NI inline void hipAssert(hipError_t code, const char *file, int line, bool abort=true) {
+      NI inline void hipAssert(hipError_t code, const char *file, int line, bool abort=true) {
         if (code != hipSuccess) {
           printf("%s:%d HIP runtime error %s\n", file, line, hipGetErrorString(code));
           if (abort) {
@@ -105,14 +115,15 @@
     /** Similar to HIPE but abort the computation in addition, either with `assert` (GPU) or `exit` (CPU).
     */
     #define HIPEX(result) { ::battery::impl::hipAssert((result), __FILE__, __LINE__, true); }
-
-  #endif // BATTERY_CUDA_BACKEND / BATTERY_HIP_BACKEND
+  #endif // BATTERY_HIP_BACKEND || BATTERY_HIP_BUILD
 
 #else // !BATTERY_GPU_ENABLED (CPU only)
   #define CUDA_GLOBAL
   #define CUDA
   #define CUDAE(S) S
   #define CUDAEX(S) S
+  #define HIPE(S) S
+  #define HIPEX(S) S
   #define NI
   #define INLINE inline
 #endif // BATTERY_GPU_ENABLED

--- a/include/battery/vector.hpp
+++ b/include/battery/vector.hpp
@@ -192,7 +192,7 @@ private:
   CUDA this_type& assignment(const vector<U, Allocator2>& other) {
     reserve(other.size());
     constexpr bool fast_copy =
-      #ifdef __CUDA_ARCH__
+      #ifdef BATTERY_DEVICE_CODE
         std::is_same_v<value_type, U>
         && std::is_same_v<Allocator2, allocator_type>
         && std::is_trivially_copyable_v<value_type>;

--- a/tests/allocator_test_gpu_hip.cpp
+++ b/tests/allocator_test_gpu_hip.cpp
@@ -16,7 +16,10 @@
 #include "battery/utility.hpp"
 #include "battery/vector.hpp"
 
-// ── Backend-transparent aliases ───────────────────────────────────────────
+// TODO: Remove this alias block once AMD verification is complete.
+// On AMD hardware BATTERY_HIP_BACKEND is always active, so the #ifdef dispatch
+// is dead code. Replace every GPU_* call site with the direct HIP call.
+// --- Backend-transparent aliases ------------------------------------------------
 #ifdef BATTERY_CUDA_BACKEND
   #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
   #define GPU_DEV_ATTR(out, attr, dev) CUDAEX(cudaDeviceGetAttribute(&(out), attr, dev))
@@ -36,7 +39,7 @@
     HIPEX(hipFuncGetAttributes(&a, f));
   }
 #endif
-// ─────────────────────────────────────────────────────────────────────────
+// ----------------------------------------------------------------------------------
 
 using namespace battery;
 

--- a/tests/allocator_test_gpu_hip.cpp
+++ b/tests/allocator_test_gpu_hip.cpp
@@ -1,12 +1,10 @@
 // HIP version of allocator_test_gpu.cpp.
-// Compiled as HIP language by CMake (files matching *_hip.cpp in HIP=ON builds).
+// Compiled as LANGUAGE HIP by CMake (files matching *_hip.cpp in HIP=ON builds).
 //
-// On AMD hardware (hip-debug):     hipcc is the compiler → BATTERY_HIP_BACKEND active.
-// On NVIDIA hardware (hip-nvidia-debug): CMake's HIP language uses nvcc →
-//   BATTERY_CUDA_BACKEND active, CUDA runtime API is used transparently.
-//
-// The GPU_* aliases below pick the right API at compile time so the test body
-// is written once.
+// Uses the HIP API unconditionally.  On NVIDIA (hip-nvidia-*) the BATTERY_HIP_BUILD
+// define is set by CMake so hip/hip_runtime.h is in scope and every hip* call maps
+// transparently to the corresponding cuda* call via the HIP portability headers.
+// On AMD (hip-debug) these are native HIP calls.
 
 #include <iostream>
 #include <cassert>
@@ -15,31 +13,6 @@
 #include "battery/shared_ptr.hpp"
 #include "battery/utility.hpp"
 #include "battery/vector.hpp"
-
-// TODO: Remove this alias block once AMD verification is complete.
-// On AMD hardware BATTERY_HIP_BACKEND is always active, so the #ifdef dispatch
-// is dead code. Replace every GPU_* call site with the direct HIP call.
-// --- Backend-transparent aliases ------------------------------------------------
-#ifdef BATTERY_CUDA_BACKEND
-  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
-  #define GPU_DEV_ATTR(out, attr, dev) CUDAEX(cudaDeviceGetAttribute(&(out), attr, dev))
-  #define GPU_CONC_MANAGED_ATTR  cudaDevAttrConcurrentManagedAccess
-  using GpuFuncAttributes = cudaFuncAttributes;
-  template<class Fn>
-  inline void gpu_func_get_attributes(GpuFuncAttributes& a, Fn* f) {
-    CUDAEX(cudaFuncGetAttributes(&a, f));
-  }
-#elif defined(BATTERY_HIP_BACKEND)
-  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
-  #define GPU_DEV_ATTR(out, attr, dev) HIPEX(hipDeviceGetAttribute(&(out), attr, dev))
-  #define GPU_CONC_MANAGED_ATTR  hipDevAttrConcurrentManagedAccess
-  using GpuFuncAttributes = hipFuncAttributes;
-  template<class Fn>
-  inline void gpu_func_get_attributes(GpuFuncAttributes& a, Fn* f) {
-    HIPEX(hipFuncGetAttributes(&a, f));
-  }
-#endif
-// ----------------------------------------------------------------------------------
 
 using namespace battery;
 
@@ -57,7 +30,7 @@ __global__ void kernel_managed_memory(iptr<managed_allocator> data) {
 void managed_memory_test() {
   iptr<managed_allocator> data = make_shared<int, managed_allocator>(0);
   kernel_managed_memory<<<1, 1>>>(data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   std::cout << *data << std::endl;
   assert(*data == 1);
 }
@@ -82,21 +55,21 @@ __global__ void kernel_test_global_memory2(iptr<global_allocator>& data) {
 void global_memory_test_passing1() {
   auto data = make_shared<iptr<global_allocator>, managed_allocator>(nullptr);
   kernel_allocate_global_memory<<<1, 1>>>(data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   kernel_test_global_memory<<<1, 1>>>(data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   kernel_free_global_memory<<<1, 1>>>(data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
 }
 
 void global_memory_test_passing2() {
   auto data = make_shared<iptr<global_allocator>, managed_allocator>(nullptr);
   kernel_allocate_global_memory<<<1, 1>>>(data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   kernel_test_global_memory2<<<1, 1>>>(*data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   kernel_free_global_memory<<<1, 1>>>(data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
 }
 
 __global__ void kernel_allocate_global_vector(shared_ptr<vector<int, global_allocator>, managed_allocator> data) {
@@ -111,11 +84,11 @@ __global__ void kernel_test_global_vector(vector<int, global_allocator>& data) {
 void global_memory_vector_passing() {
   auto data = make_shared<vector<int, global_allocator>, managed_allocator>(vector<int, global_allocator>{});
   kernel_allocate_global_vector<<<1, 1>>>(data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   kernel_test_global_vector<<<1, 1>>>(*data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   kernel_free_global_memory<<<1, 1>>>(data);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
 }
 
 CUDA void use_memory(const pool_allocator& pool_mem, int size) {
@@ -156,15 +129,15 @@ void shared_memory_max_usage(int shared_memory_size) {
   const int mem_usage = shared_memory_size / 4 - 2;
   auto measured_mem_usage = make_shared<int, managed_allocator>(0);
   kernel_measure_memory<<<1, 1>>>(*measured_mem_usage, mem_usage);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   printf("measured mem usage: %d bytes\n", *measured_mem_usage);
   kernel_compute<<<1, 1, *measured_mem_usage>>>(*measured_mem_usage, mem_usage);
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
 }
 
 void shared_memory_with_precomputation() {
-  GpuFuncAttributes attr{};
-  gpu_func_get_attributes(attr, kernel_compute);
+  hipFuncAttributes attr{};
+  HIPEX(hipFuncGetAttributes(&attr, (const void*)kernel_compute));
   printf("max dynamic shared memory size: %d bytes\n", attr.maxDynamicSharedSizeBytes);
   shared_memory_max_usage(attr.maxDynamicSharedSizeBytes);
 }
@@ -172,7 +145,7 @@ void shared_memory_with_precomputation() {
 int main() {
   int dev = 0;
   int supportsConcurrentManagedAccess = 0;
-  GPU_DEV_ATTR(supportsConcurrentManagedAccess, GPU_CONC_MANAGED_ATTR, dev);
+  HIPEX(hipDeviceGetAttribute(&supportsConcurrentManagedAccess, hipDeviceAttributeConcurrentManagedAccess, dev));
   if (!supportsConcurrentManagedAccess) {
     std::cout << "Cannot run tests because the GPU does not support concurrent access to managed memory." << std::endl;
   } else {
@@ -183,6 +156,6 @@ int main() {
   }
   shared_memory_with_precomputation();
   test_empty_pool<<<1, 1>>>();
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   return 0;
 }

--- a/tests/allocator_test_gpu_hip.cpp
+++ b/tests/allocator_test_gpu_hip.cpp
@@ -1,0 +1,185 @@
+// HIP version of allocator_test_gpu.cpp.
+// Compiled as HIP language by CMake (files matching *_hip.cpp in HIP=ON builds).
+//
+// On AMD hardware (hip-debug):     hipcc is the compiler → BATTERY_HIP_BACKEND active.
+// On NVIDIA hardware (hip-nvidia-debug): CMake's HIP language uses nvcc →
+//   BATTERY_CUDA_BACKEND active, CUDA runtime API is used transparently.
+//
+// The GPU_* aliases below pick the right API at compile time so the test body
+// is written once.
+
+#include <iostream>
+#include <cassert>
+#include "battery/bitset.hpp"
+#include "battery/allocator.hpp"
+#include "battery/shared_ptr.hpp"
+#include "battery/utility.hpp"
+#include "battery/vector.hpp"
+
+// ── Backend-transparent aliases ───────────────────────────────────────────
+#ifdef BATTERY_CUDA_BACKEND
+  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
+  #define GPU_DEV_ATTR(out, attr, dev) CUDAEX(cudaDeviceGetAttribute(&(out), attr, dev))
+  #define GPU_CONC_MANAGED_ATTR  cudaDevAttrConcurrentManagedAccess
+  using GpuFuncAttributes = cudaFuncAttributes;
+  template<class Fn>
+  inline void gpu_func_get_attributes(GpuFuncAttributes& a, Fn* f) {
+    CUDAEX(cudaFuncGetAttributes(&a, f));
+  }
+#elif defined(BATTERY_HIP_BACKEND)
+  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
+  #define GPU_DEV_ATTR(out, attr, dev) HIPEX(hipDeviceGetAttribute(&(out), attr, dev))
+  #define GPU_CONC_MANAGED_ATTR  hipDevAttrConcurrentManagedAccess
+  using GpuFuncAttributes = hipFuncAttributes;
+  template<class Fn>
+  inline void gpu_func_get_attributes(GpuFuncAttributes& a, Fn* f) {
+    HIPEX(hipFuncGetAttributes(&a, f));
+  }
+#endif
+// ─────────────────────────────────────────────────────────────────────────
+
+using namespace battery;
+
+template <class Alloc>
+using iptr = shared_ptr<int, Alloc>;
+
+//
+// Note: These tests do not work on a GPU that does not support concurrent
+// access to managed memory.
+//
+__global__ void kernel_managed_memory(iptr<managed_allocator> data) {
+  *data = 1;
+}
+
+void managed_memory_test() {
+  iptr<managed_allocator> data = make_shared<int, managed_allocator>(0);
+  kernel_managed_memory<<<1, 1>>>(data);
+  GPU_SYNC();
+  std::cout << *data << std::endl;
+  assert(*data == 1);
+}
+
+__global__ void kernel_allocate_global_memory(shared_ptr<iptr<global_allocator>, managed_allocator> data) {
+  *data = make_shared<int, global_allocator>(1);
+}
+
+template <class T>
+__global__ void kernel_free_global_memory(shared_ptr<T, managed_allocator> data) {
+  *data = T{};
+}
+
+__global__ void kernel_test_global_memory(shared_ptr<iptr<global_allocator>, managed_allocator> data) {
+  assert(**data == 1);
+}
+
+__global__ void kernel_test_global_memory2(iptr<global_allocator>& data) {
+  assert(*data == 1);
+}
+
+void global_memory_test_passing1() {
+  auto data = make_shared<iptr<global_allocator>, managed_allocator>(nullptr);
+  kernel_allocate_global_memory<<<1, 1>>>(data);
+  GPU_SYNC();
+  kernel_test_global_memory<<<1, 1>>>(data);
+  GPU_SYNC();
+  kernel_free_global_memory<<<1, 1>>>(data);
+  GPU_SYNC();
+}
+
+void global_memory_test_passing2() {
+  auto data = make_shared<iptr<global_allocator>, managed_allocator>(nullptr);
+  kernel_allocate_global_memory<<<1, 1>>>(data);
+  GPU_SYNC();
+  kernel_test_global_memory2<<<1, 1>>>(*data);
+  GPU_SYNC();
+  kernel_free_global_memory<<<1, 1>>>(data);
+  GPU_SYNC();
+}
+
+__global__ void kernel_allocate_global_vector(shared_ptr<vector<int, global_allocator>, managed_allocator> data) {
+  *data = vector<int, global_allocator>(10);
+  (*data)[5] = 10;
+}
+
+__global__ void kernel_test_global_vector(vector<int, global_allocator>& data) {
+  assert(data[5] == 10);
+}
+
+void global_memory_vector_passing() {
+  auto data = make_shared<vector<int, global_allocator>, managed_allocator>(vector<int, global_allocator>{});
+  kernel_allocate_global_vector<<<1, 1>>>(data);
+  GPU_SYNC();
+  kernel_test_global_vector<<<1, 1>>>(*data);
+  GPU_SYNC();
+  kernel_free_global_memory<<<1, 1>>>(data);
+  GPU_SYNC();
+}
+
+CUDA void use_memory(const pool_allocator& pool_mem, int size) {
+  vector<int, pool_allocator> data(size, pool_mem);
+  for(int i = 0; i < size; ++i) {
+    data[i] = i;
+  }
+  shared_ptr<int, pool_allocator> min = allocate_shared<int, pool_allocator>(pool_mem, size);
+  for(int i = 0; i < size; ++i) {
+    *min = battery::min(*min, data[i]);
+  }
+  assert(*min == 0);
+}
+
+__global__ void kernel_measure_memory(int& measured_mem_usage, int mem_usage) {
+  void* global_mem = global_allocator{}.allocate(1000000);
+  pool_allocator pool_mem(static_cast<unsigned char*>(global_mem), 1000000, alignof(int));
+  use_memory(pool_mem, mem_usage);
+  measured_mem_usage = pool_mem.used();
+  global_allocator{}.deallocate(global_mem);
+}
+
+__global__ void kernel_compute(int measured_mem_usage, int mem_usage) {
+  extern __shared__ unsigned char shared_mem[];
+  pool_allocator pool_mem(shared_mem, measured_mem_usage, alignof(int));
+  use_memory(pool_mem, mem_usage);
+  assert(measured_mem_usage == pool_mem.used());
+}
+
+__global__ void test_empty_pool() {
+  shared_ptr<int, pool_allocator> x(pool_allocator(nullptr, 0));
+  void* mem_pool = global_allocator{}.allocate(10);
+  pool_allocator pool(static_cast<unsigned char*>(mem_pool), 10);
+  x = allocate_shared<int, pool_allocator>(pool);
+}
+
+void shared_memory_max_usage(int shared_memory_size) {
+  const int mem_usage = shared_memory_size / 4 - 2;
+  auto measured_mem_usage = make_shared<int, managed_allocator>(0);
+  kernel_measure_memory<<<1, 1>>>(*measured_mem_usage, mem_usage);
+  GPU_SYNC();
+  printf("measured mem usage: %d bytes\n", *measured_mem_usage);
+  kernel_compute<<<1, 1, *measured_mem_usage>>>(*measured_mem_usage, mem_usage);
+  GPU_SYNC();
+}
+
+void shared_memory_with_precomputation() {
+  GpuFuncAttributes attr{};
+  gpu_func_get_attributes(attr, kernel_compute);
+  printf("max dynamic shared memory size: %d bytes\n", attr.maxDynamicSharedSizeBytes);
+  shared_memory_max_usage(attr.maxDynamicSharedSizeBytes);
+}
+
+int main() {
+  int dev = 0;
+  int supportsConcurrentManagedAccess = 0;
+  GPU_DEV_ATTR(supportsConcurrentManagedAccess, GPU_CONC_MANAGED_ATTR, dev);
+  if (!supportsConcurrentManagedAccess) {
+    std::cout << "Cannot run tests because the GPU does not support concurrent access to managed memory." << std::endl;
+  } else {
+    managed_memory_test();
+    global_memory_test_passing1();
+    global_memory_test_passing2();
+    global_memory_vector_passing();
+  }
+  shared_memory_with_precomputation();
+  test_empty_pool<<<1, 1>>>();
+  GPU_SYNC();
+  return 0;
+}

--- a/tests/unique_ptr_test_gpu_hip.cpp
+++ b/tests/unique_ptr_test_gpu_hip.cpp
@@ -1,0 +1,117 @@
+// HIP version of unique_ptr_test_gpu.cpp.
+// Compiled as HIP language by CMake (files matching *_hip.cpp in HIP=ON builds).
+//
+// On AMD hardware (hip-debug):            hipcc → BATTERY_HIP_BACKEND active.
+// On NVIDIA hardware (hip-nvidia-debug):  CMake's HIP language uses nvcc →
+//   BATTERY_CUDA_BACKEND active, CUDA runtime API used transparently.
+//
+// The GPU_* aliases below pick the correct backend API at compile time.
+
+#include <iostream>
+#include <cassert>
+#include "battery/allocator.hpp"
+#include "battery/unique_ptr.hpp"
+#include "battery/utility.hpp"
+#include "battery/vector.hpp"
+
+// TODO: Remove this alias block once AMD verification is complete.
+// On AMD hardware BATTERY_HIP_BACKEND is always active, so the #ifdef dispatch
+// is dead code. Replace every GPU_* call site with the direct HIP call and
+// inline gpu_launch_cooperative (note: hip/cudaLaunchCooperativeKernel differ
+// in signature so it cannot be removed entirely, just de-abstracted).
+//----- Backend-transparent aliases ------------------------------------------
+#ifdef BATTERY_CUDA_BACKEND
+  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
+  #define GPU_DEV_ATTR(out, attr, dev) CUDAEX(cudaDeviceGetAttribute(&(out), attr, dev))
+  #define GPU_ATTR_COOP_LAUNCH  cudaDevAttrCooperativeLaunch
+
+  template<class Fn>
+  void gpu_launch_cooperative(Fn* fn, dim3 grid, dim3 block, void** args) {
+    CUDAEX(cudaLaunchCooperativeKernel((void*)fn, grid, block, args));
+  }
+#elif defined(BATTERY_HIP_BACKEND)
+  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
+  #define GPU_DEV_ATTR(out, attr, dev) HIPEX(hipDeviceGetAttribute(&(out), attr, dev))
+  #define GPU_ATTR_COOP_LAUNCH  hipDevAttrCooperativeLaunch
+
+  template<class Fn>
+  void gpu_launch_cooperative(Fn* fn, dim3 grid, dim3 block, void** args) {
+    HIPEX(hipLaunchCooperativeKernel((void*)fn, grid, block, args, 0, nullptr));
+  }
+#endif
+// -------------------------------------------------------------------------------
+
+using namespace battery;
+
+__global__ void block_kernel(vector<vector<int, managed_allocator>, managed_allocator>* v_ptr)
+{
+  unique_ptr<int, global_allocator> block_data;
+  int& data = make_unique_block(block_data, 100);
+  (*v_ptr)[blockIdx.x][threadIdx.x] = data;
+  __syncthreads();
+  if(threadIdx.x == 0) {
+    data = 1000;
+  }
+  __syncthreads();
+  (*v_ptr)[blockIdx.x][threadIdx.x] += data;
+  // This last `__syncthreads()` is needed to avoid destructing `unique_ptr` before all threads finished using `data`.
+  __syncthreads();
+}
+
+void make_unique_block_test() {
+  auto vptr = make_unique<vector<vector<int, managed_allocator>, managed_allocator>, managed_allocator>(10, vector<int, managed_allocator>(10));
+  block_kernel<<<10, 10>>>(vptr.get());
+  GPU_SYNC();
+  for(int i = 0; i < 10; ++i) {
+    for(int j = 0; j < 10; ++j) {
+      if((*vptr)[i][j] != 1100) {
+        printf("(*vptr)[%d][%d] (= %d) != 1100 \n", i, j, (*vptr)[i][j]);
+        assert(false);
+      }
+    }
+  }
+}
+
+__global__ void grid_kernel(vector<int, managed_allocator>* v_ptr) {
+  auto grid = cooperative_groups::this_grid();
+  unique_ptr<int, global_allocator> grid_data;
+  int& data = make_unique_grid(grid_data, 100);
+  (*v_ptr)[blockIdx.x] = data;
+  grid.sync();
+  if(blockIdx.x == 0) {
+    data = 1000;
+  }
+  grid.sync();
+  (*v_ptr)[blockIdx.x] += data;
+  grid.sync();
+}
+
+void make_unique_grid_test() {
+  auto vptr = make_unique<vector<int, managed_allocator>, managed_allocator>(10);
+  auto ptr = vptr.get();
+  void *kernelArgs[] = { &ptr };
+  dim3 dimBlock(1, 1, 1);
+  dim3 dimGrid(10, 1, 1);
+  gpu_launch_cooperative(grid_kernel, dimGrid, dimBlock, kernelArgs);
+  GPU_SYNC();
+  for(int i = 0; i < 10; ++i) {
+    if((*vptr)[i] != 1100) {
+      printf("(*vptr)[%d] (= %d) != 1100 \n", i, (*vptr)[i]);
+      assert(false);
+    }
+  }
+}
+
+int main() {
+  make_unique_block_test();
+  int supportsCoopLaunch = 0;
+  GPU_DEV_ATTR(supportsCoopLaunch, GPU_ATTR_COOP_LAUNCH, 0);
+  if(supportsCoopLaunch == 1) {
+    make_unique_grid_test();
+  }
+  else {
+    printf("Note: skipping unique_ptr grid test because device does not support cooperative launch.\n");
+  }
+  printf("unique_ptr_test_gpu_hip complete.\n");
+  return 0;
+}

--- a/tests/unique_ptr_test_gpu_hip.cpp
+++ b/tests/unique_ptr_test_gpu_hip.cpp
@@ -1,11 +1,8 @@
 // HIP version of unique_ptr_test_gpu.cpp.
 // Compiled as HIP language by CMake (files matching *_hip.cpp in HIP=ON builds).
 //
-// On AMD hardware (hip-debug):            hipcc → BATTERY_HIP_BACKEND active.
-// On NVIDIA hardware (hip-nvidia-debug):  CMake's HIP language uses nvcc →
-//   BATTERY_CUDA_BACKEND active, CUDA runtime API used transparently.
-//
-// The GPU_* aliases below pick the correct backend API at compile time.
+// Uses the HIP API unconditionally: on NVIDIA (hip-nvidia-*) hip* calls map
+// transparently to cuda* via the HIP portability headers.
 
 #include <iostream>
 #include <cassert>
@@ -13,33 +10,6 @@
 #include "battery/unique_ptr.hpp"
 #include "battery/utility.hpp"
 #include "battery/vector.hpp"
-
-// TODO: Remove this alias block once AMD verification is complete.
-// On AMD hardware BATTERY_HIP_BACKEND is always active, so the #ifdef dispatch
-// is dead code. Replace every GPU_* call site with the direct HIP call and
-// inline gpu_launch_cooperative (note: hip/cudaLaunchCooperativeKernel differ
-// in signature so it cannot be removed entirely, just de-abstracted).
-//----- Backend-transparent aliases ------------------------------------------
-#ifdef BATTERY_CUDA_BACKEND
-  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
-  #define GPU_DEV_ATTR(out, attr, dev) CUDAEX(cudaDeviceGetAttribute(&(out), attr, dev))
-  #define GPU_ATTR_COOP_LAUNCH  cudaDevAttrCooperativeLaunch
-
-  template<class Fn>
-  void gpu_launch_cooperative(Fn* fn, dim3 grid, dim3 block, void** args) {
-    CUDAEX(cudaLaunchCooperativeKernel((void*)fn, grid, block, args));
-  }
-#elif defined(BATTERY_HIP_BACKEND)
-  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
-  #define GPU_DEV_ATTR(out, attr, dev) HIPEX(hipDeviceGetAttribute(&(out), attr, dev))
-  #define GPU_ATTR_COOP_LAUNCH  hipDevAttrCooperativeLaunch
-
-  template<class Fn>
-  void gpu_launch_cooperative(Fn* fn, dim3 grid, dim3 block, void** args) {
-    HIPEX(hipLaunchCooperativeKernel((void*)fn, grid, block, args, 0, nullptr));
-  }
-#endif
-// -------------------------------------------------------------------------------
 
 using namespace battery;
 
@@ -61,7 +31,7 @@ __global__ void block_kernel(vector<vector<int, managed_allocator>, managed_allo
 void make_unique_block_test() {
   auto vptr = make_unique<vector<vector<int, managed_allocator>, managed_allocator>, managed_allocator>(10, vector<int, managed_allocator>(10));
   block_kernel<<<10, 10>>>(vptr.get());
-  GPU_SYNC();
+  HIPEX(hipDeviceSynchronize());
   for(int i = 0; i < 10; ++i) {
     for(int j = 0; j < 10; ++j) {
       if((*vptr)[i][j] != 1100) {
@@ -92,8 +62,8 @@ void make_unique_grid_test() {
   void *kernelArgs[] = { &ptr };
   dim3 dimBlock(1, 1, 1);
   dim3 dimGrid(10, 1, 1);
-  gpu_launch_cooperative(grid_kernel, dimGrid, dimBlock, kernelArgs);
-  GPU_SYNC();
+  HIPEX(hipLaunchCooperativeKernel((void*)grid_kernel, dimGrid, dimBlock, kernelArgs, 0, nullptr));
+  HIPEX(hipDeviceSynchronize());
   for(int i = 0; i < 10; ++i) {
     if((*vptr)[i] != 1100) {
       printf("(*vptr)[%d] (= %d) != 1100 \n", i, (*vptr)[i]);
@@ -105,7 +75,7 @@ void make_unique_grid_test() {
 int main() {
   make_unique_block_test();
   int supportsCoopLaunch = 0;
-  GPU_DEV_ATTR(supportsCoopLaunch, GPU_ATTR_COOP_LAUNCH, 0);
+  HIPEX(hipDeviceGetAttribute(&supportsCoopLaunch, hipDeviceAttributeCooperativeLaunch, 0));
   if(supportsCoopLaunch == 1) {
     make_unique_grid_test();
   }

--- a/tests/utility_test_cpu_gpu_hip.cpp
+++ b/tests/utility_test_cpu_gpu_hip.cpp
@@ -15,6 +15,9 @@
 #include "battery/allocator.hpp"
 #include "battery/utility.hpp"
 
+// TODO: Remove this alias block once AMD verification is complete.
+// On AMD hardware BATTERY_HIP_BACKEND is always active, so the #ifdef dispatch
+// is dead code. Replace every GPU_* call site with the direct HIP call.
 // ── Backend-transparent aliases ───────────────────────────────────────────
 #ifdef BATTERY_CUDA_BACKEND
   #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())

--- a/tests/utility_test_cpu_gpu_hip.cpp
+++ b/tests/utility_test_cpu_gpu_hip.cpp
@@ -1,0 +1,267 @@
+// HIP version of utility_test_cpu_gpu.cpp.
+// Compiled as HIP language by CMake (files matching *_hip.cpp in HIP=ON builds).
+//
+// On AMD hardware (hip-debug):            hipcc → BATTERY_HIP_BACKEND active.
+// On NVIDIA hardware (hip-nvidia-debug):  CMake's HIP language uses nvcc →
+//   BATTERY_CUDA_BACKEND active, CUDA runtime API is used transparently.
+//
+// The GPU_SYNC() alias below picks the right synchronisation call at compile time.
+
+// Copyright 2022 Pierre Talbot
+
+#include <vector>
+#include "battery/bitset.hpp"
+#include "battery/memory.hpp"
+#include "battery/allocator.hpp"
+#include "battery/utility.hpp"
+
+// ── Backend-transparent aliases ───────────────────────────────────────────
+#ifdef BATTERY_CUDA_BACKEND
+  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
+#elif defined(BATTERY_HIP_BACKEND)
+  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
+#endif
+// ─────────────────────────────────────────────────────────────────────────
+
+template<class T>
+CUDA const char* name_of_type() {
+  if constexpr(std::is_same_v<T, char>) { return "char"; }
+  else if constexpr(std::is_same_v<T, short>) { return "short"; }
+  else if constexpr(std::is_same_v<T, int>) { return "int"; }
+  else if constexpr(std::is_same_v<T, long int>) { return "long int"; }
+  else if constexpr(std::is_same_v<T, long long int>) { return "long long int"; }
+  else if constexpr(std::is_same_v<T, unsigned char>) { return "unsigned char"; }
+  else if constexpr(std::is_same_v<T, unsigned short>) { return "unsigned short"; }
+  else if constexpr(std::is_same_v<T, unsigned int>) { return "unsigned int"; }
+  else if constexpr(std::is_same_v<T, unsigned long int>) { return "unsigned long int"; }
+  else if constexpr(std::is_same_v<T, unsigned long long int>) { return "unsigned long long int"; }
+  else if constexpr(std::is_same_v<T, float>) { return "float"; }
+  else if constexpr(std::is_same_v<T, double>) { return "double"; }
+  else {
+    static_assert(std::is_same_v<T, char>, "Type unsupported in name_of_type.");
+    return "unknown";
+  }
+}
+
+enum UtilityOperation {
+  RU_CAST,
+  RD_CAST,
+  POPCOUNT,
+  COUNTL_ZERO,
+  COUNTL_ONE,
+  COUNTR_ZERO,
+  COUNTR_ONE
+};
+
+CUDA const char* name_of_utility_op(UtilityOperation op) {
+  switch(op) {
+    case RU_CAST: return "ru_cast";
+    case RD_CAST: return "rd_cast";
+    case POPCOUNT: return "popcount";
+    case COUNTL_ZERO: return "countl_zero";
+    case COUNTL_ONE: return "countl_one";
+    case COUNTR_ZERO: return "countr_zero";
+    case COUNTR_ONE: return "countr_one";
+    default: assert(0); return "unknown";
+  }
+}
+
+template<class R, class T>
+CUDA R run_utility_op(T input, UtilityOperation op) {
+  if constexpr(std::is_unsigned_v<T>) {
+    switch(op) {
+      case POPCOUNT: return battery::popcount(input);
+      case COUNTL_ZERO: return battery::countl_zero(input);
+      case COUNTL_ONE: return battery::countl_one(input);
+      case COUNTR_ZERO: return battery::countr_zero(input);
+      case COUNTR_ONE: return battery::countr_one(input);
+      default: break;
+    }
+  }
+  switch(op) {
+    case RU_CAST: return battery::ru_cast<R>(input);
+    case RD_CAST: return battery::rd_cast<R>(input);
+    default: assert(0); return R{};
+  }
+}
+
+template<class R, class T>
+CUDA_GLOBAL void run_utility_op_gpu(R* res, T input, UtilityOperation op) {
+  *res = run_utility_op<R>(input, op);
+}
+
+template<class T, class R>
+void analyse_test_result(T input, R expect, R cpu_result, R gpu_result, UtilityOperation op) {
+  if(cpu_result != expect || gpu_result != expect) {
+    const char* op_name = name_of_utility_op(op);
+    printf("%s %s(%s)\n", name_of_type<R>(), op_name, name_of_type<T>());
+    printf("%s(", op_name);
+    ::battery::print(input);
+    printf(") == ");
+    ::battery::print(expect);
+    printf("\n%s(", op_name);
+    ::battery::print(input);
+    printf(")__CPU == ");
+    ::battery::print(cpu_result);
+    printf("\n%s(", op_name);
+    ::battery::print(input);
+    printf(")__GPU == ");
+    ::battery::print(gpu_result);
+    printf("\n");
+    exit(EXIT_FAILURE);
+  }
+}
+
+template<class T, class R>
+void test_utility_ops(std::vector<T> inputs, std::vector<R> outputs, UtilityOperation op) {
+  assert(inputs.size() == outputs.size());
+  // Add testing for infinities for the casting operations.
+  if(op == RU_CAST || op == RD_CAST) {
+    if constexpr(std::is_signed_v<T>) {
+      inputs.push_back(battery::limits<T>::neg_inf());
+      outputs.push_back(battery::limits<R>::neg_inf());
+    }
+    inputs.push_back(battery::limits<T>::inf());
+    outputs.push_back(battery::limits<R>::inf());
+  }
+  battery::managed_allocator managed_allocator;
+  for(int i = 0; i < (int)inputs.size(); ++i) {
+    R cpu_result = run_utility_op<R>(inputs[i], op);
+    R* gpu_result = new(managed_allocator) R();
+    run_utility_op_gpu<R><<<1, 1>>>(gpu_result, inputs[i], op);
+    GPU_SYNC();
+    analyse_test_result(inputs[i], outputs[i], cpu_result, *gpu_result, op);
+  }
+}
+
+template<class From>
+void limits_tests_round_cast(UtilityOperation op) {
+  test_utility_ops<From, float>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, double>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, char>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, unsigned char>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, short>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, unsigned short>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, int>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, long long int>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, unsigned int>({0, 1, 100}, {0, 1, 100}, op);
+  test_utility_ops<From, unsigned long long int>({0, 1, 100}, {0, 1, 100}, op);
+}
+
+template<class From>
+void limits_tests_round_cast() {
+  limits_tests_round_cast<From>(RU_CAST);
+  limits_tests_round_cast<From>(RD_CAST);
+}
+
+void limits_tests_round_cast_all() {
+  limits_tests_round_cast<float>();
+  limits_tests_round_cast<double>();
+  limits_tests_round_cast<char>();
+  limits_tests_round_cast<unsigned char>();
+  limits_tests_round_cast<short>();
+  limits_tests_round_cast<unsigned short>();
+  limits_tests_round_cast<int>();
+  limits_tests_round_cast<long long int>();
+  limits_tests_round_cast<unsigned int>();
+  limits_tests_round_cast<unsigned long long int>();
+}
+
+constexpr int int_not_float = 100000001;
+constexpr long long int long_long_not_double = 100000000000000001;
+
+template<class I>
+void cast_I_to_float_double() {
+  static_assert(sizeof(I) >= sizeof(int));
+  test_utility_ops<I, float>({int_not_float}, {100000008.0f}, RU_CAST);
+  test_utility_ops<I, float>({int_not_float}, {100000000.0f}, RD_CAST);
+
+  if constexpr(std::is_signed_v<I>) {
+    test_utility_ops<I, float>({-int_not_float}, {-100000000.0f}, RU_CAST);
+    test_utility_ops<I, float>({-int_not_float}, {-100000008.0f}, RD_CAST);
+  }
+
+  if constexpr(sizeof(I) >= sizeof(long long int)) {
+    test_utility_ops<I, float>({long_long_not_double}, {100000007020609536.0f}, RU_CAST);
+    test_utility_ops<I, float>({long_long_not_double}, {99999998430674944.0f}, RD_CAST);
+    test_utility_ops<I, double>({int_not_float, long_long_not_double}, {100000001.0, 100000000000000016.0}, RU_CAST);
+    test_utility_ops<I, double>({int_not_float, long_long_not_double}, {100000001.0, 100000000000000000.0}, RD_CAST);
+
+    if constexpr(std::is_signed_v<I>) {
+      test_utility_ops<I, float>({-long_long_not_double}, {-99999998430674944.0f}, RU_CAST);
+      test_utility_ops<I, float>({-long_long_not_double}, {-100000007020609536.0f}, RD_CAST);
+      test_utility_ops<I, double>({-int_not_float, -long_long_not_double}, {-100000001.0, -100000000000000000.0}, RU_CAST);
+      test_utility_ops<I, double>({-int_not_float, -long_long_not_double}, {-100000001.0, -100000000000000016.0}, RD_CAST);
+    }
+  }
+}
+
+template<class I>
+void cast_F_to_integers() {
+  if constexpr(std::is_signed_v<I>) {
+    test_utility_ops<float, I>({-10.0f, -10.5f}, {-10, -10}, RU_CAST);
+    test_utility_ops<double, I>({-10.0, -10.5}, {-10, -10}, RU_CAST);
+    test_utility_ops<float, I>({-10.0f, -10.5f}, {-10, -11}, RD_CAST);
+    test_utility_ops<double, I>({-10.0, -10.5}, {-10, -11}, RD_CAST);
+  }
+  test_utility_ops<float, I>({0.f, 10.f, 10.5f}, {0, 10, 11}, RU_CAST);
+  test_utility_ops<double, I>({0., 10., 10.5}, {0, 10, 11}, RU_CAST);
+  test_utility_ops<float, I>({0.f, 10.f, 10.5f}, {0, 10, 10}, RD_CAST);
+  test_utility_ops<double, I>({0., 10., 10.5}, {0, 10, 10}, RD_CAST);
+}
+
+void test_all_casts() {
+  limits_tests_round_cast_all();
+
+  cast_I_to_float_double<int>();
+  cast_I_to_float_double<unsigned int>();
+  cast_I_to_float_double<long long int>();
+  cast_I_to_float_double<unsigned long long int>();
+
+  cast_F_to_integers<char>();
+  cast_F_to_integers<unsigned char>();
+  cast_F_to_integers<short>();
+  cast_F_to_integers<unsigned short>();
+  cast_F_to_integers<int>();
+  cast_F_to_integers<unsigned int>();
+  cast_F_to_integers<long long int>();
+  cast_F_to_integers<unsigned long long int>();
+
+  test_utility_ops<double, float>({100000000000000016.0}, {100000007020609536.0f}, RU_CAST);
+  test_utility_ops<double, float>({100000000000000016.0}, {99999998430674944.0f}, RD_CAST);
+}
+
+template<class I>
+void test_bitwise_operations() {
+  constexpr I bits = sizeof(I) * CHAR_BIT;
+  test_utility_ops<I, int>(
+    {0, 1, ((I)1) << (bits-1), (I)1 | ((I)1 << (bits-1)),  battery::limits<I>::inf()},
+    {0, 1, 1,             2,                    bits},
+    POPCOUNT);
+  test_utility_ops<I, int>(
+    {0,    1,      (I)1 << 2, (I)1 << (bits-1), (I)1 | ((I)1 << (bits-1)), battery::limits<I>::inf()},
+    {bits, bits-1, bits-3, 0,             0,                   0},
+    COUNTL_ZERO);
+  test_utility_ops<I, int>(
+    {0,    1, (I)1 << 2, (I)1 << (bits-1), (I)1 | ((I)1 << (bits-1)), battery::limits<I>::inf()},
+    {bits, 0, 2,      bits-1,        0,                   0},
+    COUNTR_ZERO);
+  test_utility_ops<I, int>(
+    {0, 1, (I)1 << 2, (I)1 << (bits-1), (I)1 | ((I)1 << (bits-1)), battery::limits<I>::inf(), (I)1 << (bits-1) | (I)1 << (bits-2)},
+    {0, 0, 0,      1,             1,                   bits,                      2},
+    COUNTL_ONE);
+  test_utility_ops<I, int>(
+    {0, 1, (I)1 << 2, (I)1 << (bits-1), (I)1 | ((I)1 << (bits-1)), battery::limits<I>::inf(), 1 | 2},
+    {0, 1, 0,      0,             1,                   bits,                      2},
+    COUNTR_ONE);
+}
+
+int main() {
+  test_all_casts();
+  test_bitwise_operations<unsigned char>();
+  test_bitwise_operations<unsigned short>();
+  test_bitwise_operations<unsigned int>();
+  test_bitwise_operations<unsigned long long int>();
+  printf("utility_test_cpu_gpu_hip complete.\n");
+  return 0;
+}

--- a/tests/utility_test_cpu_gpu_hip.cpp
+++ b/tests/utility_test_cpu_gpu_hip.cpp
@@ -1,11 +1,7 @@
 // HIP version of utility_test_cpu_gpu.cpp.
-// Compiled as HIP language by CMake (files matching *_hip.cpp in HIP=ON builds).
-//
-// On AMD hardware (hip-debug):            hipcc → BATTERY_HIP_BACKEND active.
-// On NVIDIA hardware (hip-nvidia-debug):  CMake's HIP language uses nvcc →
-//   BATTERY_CUDA_BACKEND active, CUDA runtime API is used transparently.
-//
-// The GPU_SYNC() alias below picks the right synchronisation call at compile time.
+// Compiled as LANGUAGE HIP by CMake (files matching *_hip.cpp in HIP=ON builds).
+// Uses the HIP API unconditionally.  On NVIDIA (hip-nvidia-*) BATTERY_HIP_BUILD is set
+// by CMake so hip/hip_runtime.h is in scope; hip* calls map to cuda* via HIP headers.
 
 // Copyright 2022 Pierre Talbot
 
@@ -15,16 +11,7 @@
 #include "battery/allocator.hpp"
 #include "battery/utility.hpp"
 
-// TODO: Remove this alias block once AMD verification is complete.
-// On AMD hardware BATTERY_HIP_BACKEND is always active, so the #ifdef dispatch
-// is dead code. Replace every GPU_* call site with the direct HIP call.
-// ── Backend-transparent aliases ───────────────────────────────────────────
-#ifdef BATTERY_CUDA_BACKEND
-  #define GPU_SYNC() CUDAEX(cudaDeviceSynchronize())
-#elif defined(BATTERY_HIP_BACKEND)
-  #define GPU_SYNC() HIPEX(hipDeviceSynchronize())
-#endif
-// ─────────────────────────────────────────────────────────────────────────
+#define GPU_SYNC() HIPEX(hipDeviceSynchronize())
 
 template<class T>
 CUDA const char* name_of_type() {
@@ -132,7 +119,7 @@ void test_utility_ops(std::vector<T> inputs, std::vector<R> outputs, UtilityOper
     R cpu_result = run_utility_op<R>(inputs[i], op);
     R* gpu_result = new(managed_allocator) R();
     run_utility_op_gpu<R><<<1, 1>>>(gpu_result, inputs[i], op);
-    GPU_SYNC();
+    HIPEX(hipDeviceSynchronize());
     analyse_test_result(inputs[i], outputs[i], cpu_result, *gpu_result, op);
   }
 }


### PR DESCRIPTION
#Add HIP backend support (AMD ROCm)

### Summary

This PR adds HIP as a first-class, compile-time-selectable GPU backend targeting **AMD ROCm hardware**. All existing CPU and CUDA behaviour is **completely unchanged**. HIP support is opt-in via `-DHIP=ON -DGPU=OFF` and affects no currently-passing tests.

> **Note on NVIDIA-via-HIP scaffolding:** This PR includes temporary `hip-nvidia-*` CMake presets and associated build scaffolding that allow the HIP code to be compiled and tested on a NVIDIA machine (using the HIP portability headers that map `hip*` -> `cuda*`). **This is a development convenience only** - it is not a supported end-user configuration and will be removed once the code is validated on real AMD hardware. NVIDIA users should continue using the existing `GPU=ON` CUDA presets.

**Test results (verified on NVIDIA hardware via HIP portability layer as a development proxy):**
- 35/35 CPU tests 
- 38/38 CUDA tests (`gpu-debug`) 
- 38/38 HIP tests (`hip-nvidia-debug`, temporary dev preset) 

---

### Motivation

Users running on AMD GPUs (ROCm) cannot use the library today. HIP provides portability across AMD and NVIDIA hardware with near-identical syntax to CUDA. The goal is to support AMD hardware without forking the codebase or breaking existing CUDA users.

---

### Design approach

HIP is selected entirely at compile time. There is no runtime dispatch. The key principle is: `*_hip.cpp` files call the HIP API directly - on AMD this is native ROCm; on the temporary NVIDIA dev path the HIP portability headers map `hip*` to `cuda*` transparently, so no backend-switching logic is needed in test or application code.

The supported backends are:

| Backend | CMake option | Compiler | Required |
|---|---|---|---|
| CPU only | `GPU=OFF HIP=OFF` | Any C++20 | C++20 compiler |
| CUDA / NVIDIA | `GPU=ON` | nvcc | CUDA Toolkit 12+ |
| **HIP / AMD** *(this PR)* | `HIP=ON` | hipcc | ROCm 6+ |
| ~~HIP / NVIDIA~~ | *(temporary dev scaffolding - not for end users)* | - | - |

---

### Changes by area

#### `include/battery/utility.hpp` - backend detection macros
Replaces raw `__CUDACC__` / `__CUDA_ARCH__` checks throughout the codebase with clean, named macros:
- `BATTERY_GPU_ENABLED` - any GPU compiler active
- `BATTERY_DEVICE_CODE` - inside a device function body
- `BATTERY_CUDA_BACKEND` - nvcc without HIP wrapper
- `BATTERY_HIP_BACKEND` - hipcc (AMD or NVIDIA via hipcc)
- `BATTERY_HIP_BUILD` - injected by CMake when `HIP=ON`, covering the NVIDIA-via-HIP dev path where nvcc is the compiler and `__HIPCC__` is never set
- `HIPE(result)` / `HIPEX(result)` - HIP error-check macros, parallel to the existing `CUDAE`/`CUDAEX`; `hipAssert` is host-only since `hipGetErrorString` is a host function; CPU no-op stubs provided so headers stay includable in CPU translation units

`CUDAE`/`CUDAEX` and all existing macros are **unchanged**.

#### `include/battery/allocator.hpp` - backend-dispatching allocation helpers
Five internal `battery::impl` helpers (`gpu_malloc`, `gpu_free`, `gpu_malloc_managed`, `gpu_malloc_host`, `gpu_free_host`) replace direct CUDA API calls in the allocator classes. Each uses a strict three-branch guard with an explicit `#error` fallback - no silent fallthrough:
```cpp
#if defined(BATTERY_CUDA_BACKEND) && !defined(BATTERY_HIP_BUILD)  // -> cudaMalloc*
#elif defined(BATTERY_HIP_BACKEND) || defined(BATTERY_HIP_BUILD)  // -> hipMalloc*
#else
  #error "no GPU backend defined"
#endif
```
Uses ROCm 6.x non-deprecated names: `hipHostMalloc` / `hipHostFree`.

#### `include/battery/memory.hpp` - HIP scoped atomics
- Scope constants: `hip_scope_block/device/system` mapping to `__HIP_MEMORY_SCOPE_*`
- `hip_atomic_wrapper<T, Scope>` wrapping `__hip_atomic_*` intrinsics, compatible with the existing `copyable_atomic` interface
- `atomic_memory_block/grid/multi_grid` aliases for HIP, mirroring the CUDA ones

#### `include/battery/unique_ptr.hpp` - HIP cooperative groups
- Conditional include of `<hip/hip_cooperative_groups.h>` vs `<cooperative_groups.h>`
- `battery::invoke_one` device shim for HIP (`invoke_one` is absent from HIP cooperative groups; implemented via `g.thread_rank() == 0`)
- `make_unique_block` / `make_unique_grid` guard changed from `BATTERY_CUDA_BACKEND` to `BATTERY_GPU_ENABLED` so both backends compile
- `assert(ptr)` instead of `assert(ptr != nullptr)` to avoid `__nv_bool`/`nullptr_t` clash when HIP portability headers are loaded alongside nvcc

#### `CMakeLists.txt`
- `option(HIP ...)` with mutual exclusion guard against `GPU=ON`
- `project(... LANGUAGES HIP CXX)` path
- `find_package(hip REQUIRED)` + `target_link_libraries(cuda_battery INTERFACE hip::host)` - handles AMD (`amdhip64`) and the dev NVIDIA path (`cudart` wrapper) in one target
- `target_compile_definitions(cuda_battery INTERFACE BATTERY_HIP_BUILD)` when `HIP=ON`
- Section III test discovery: `tests/*_hip.cpp` compiled as `LANGUAGE HIP`
- *(temporary dev scaffolding)* `CUDA::cuda_driver` linked conditionally when `CUDAToolkit_FOUND` - needed on the NVIDIA dev path because `hipDeviceGetAttribute` routes through `libcuda.so`; will be removed in Phase 5

#### `CMakePresets.json`
- `hip-debug` and `hip-release` - the permanent AMD presets
- *(temporary)* `hip-nvidia-debug` and `hip-nvidia-release` - NVIDIA dev presets, to be deleted after AMD validation

#### HIP test files (`tests/*_hip.cpp`)
Three new HIP test files mirroring the existing `*_gpu.cpp` suite. They call the HIP API **directly** with no `GPU_*` abstraction macros - on AMD this is native; on the NVIDIA dev path the portability headers handle the mapping:
- `tests/allocator_test_gpu_hip.cpp`
- `tests/utility_test_cpu_gpu_hip.cpp`
- `tests/unique_ptr_test_gpu_hip.cpp`

#### Demo (`demo/`)
Four new HIP demo source files and test, `demo/CMakeLists.txt` extended with the same `hip::host` / `CUDA::cuda_driver` treatment, `demo/README.md` updated with AMD build instructions.

---

### What remains after this PR (Last Phase)

Once tested on AMD hardware, a small follow-up is needed to remove the NVIDIA dev scaffolding:

- Delete `hip-nvidia-debug`, `hip-nvidia-release`, `default-hip-nvidia` from `CMakePresets.json`
- Remove `find_package(CUDAToolkit ...)` and `CUDA::cuda_driver` link blocks from `CMakeLists.txt` and `demo/CMakeLists.txt`

No header or test changes are needed - the `*_hip.cpp` files already call the HIP API natively.

---

### Files changed

| Category | Files |
|---|---|
| Headers | `include/battery/utility.hpp`, `allocator.hpp`, `memory.hpp`, `unique_ptr.hpp`, `vector.hpp` |
| Build | `CMakeLists.txt`, `CMakePresets.json`, `demo/CMakeLists.txt` |
| Tests | `tests/allocator_test_gpu_hip.cpp`, `utility_test_cpu_gpu_hip.cpp`, `unique_ptr_test_gpu_hip.cpp` |
| Demo | `demo/src/simple_hip.cpp`, `demo_hip.cpp`, `inkernel_allocation_hip.cpp`, `demo/tests/demo_test_gpu_hip.cpp` |
| Docs | `README.md`, `demo/README.md`, `CHANGELOG.md` |

18 files changed, 1 446 insertions(+), 195 deletions(−).


### TODO

- [ ] Validate functionality on AMD hardware
- [ ] Cleanup code to remove `hip-nvidia-*` related code
